### PR TITLE
feat: add account checking service and update API endpoint

### DIFF
--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -3,11 +3,12 @@ import { Keypair, Operation } from '@stellar/stellar-sdk';
 import { getNetworkConfig, serverKeypair } from './config/stellar';
 import { buildAndSubmitTx } from './services/transaction.service';
 import { ensureFunded } from './services/friendbot';
+import { checkAccount } from './services/account.service';
 
 const app = express();
 const port = process.env.PORT || 3002;
 
-app.get('/', (req, res) => {
+app.get('/', (req: express.Request, res: express.Response) => {
   res.json({
     service: 'MixMatch Stellar Service',
     status: 'Active',
@@ -15,26 +16,27 @@ app.get('/', (req, res) => {
   });
 });
 
+app.get(
+  '/account/:publicKey',
+  async (req: express.Request, res: express.Response) => {
+    try {
+      const { publicKey } = req.params;
+      const result = await checkAccount(publicKey);
+
+      if (!result.exists) {
+        res.status(404).json(result);
+        return;
+      }
+
+      res.json(result);
+    } catch (error: any) {
+      res.status(400).json({ error: error.message });
+    }
+  },
+);
+
 app.listen(port, async () => {
   console.log(`✨ Stellar Service running on port ${port}`);
-
-  try {
-    console.log('STARTING TEST: Creating a new account on-chain...');
-
-    const fakeDjParams = Keypair.random();
-
-    const createOp = Operation.createAccount({
-      destination: fakeDjParams.publicKey(),
-      startingBalance: '10',
-    });
-
-    await buildAndSubmitTx([createOp]);
-
-    console.log('TEST PASSED: Transaction Builder works!');
-  } catch (e) {
-    console.error('Test Failed:', e);
-  }
-  console.log(`   Public Key: ${serverKeypair.publicKey()}`);
 
   await ensureFunded();
 });

--- a/apps/stellar-service/src/services/account.service.ts
+++ b/apps/stellar-service/src/services/account.service.ts
@@ -1,0 +1,31 @@
+import { server } from '../config/stellar';
+
+export const checkAccount = async (publicKey: string) => {
+  try {
+    const account = await server.loadAccount(publicKey);
+
+    const balances = account.balances.map((b) => ({
+      asset: b.asset_type === 'native' ? 'XLM' : b.asset_code,
+      balance: b.balance,
+    }));
+
+    return {
+      exists: true,
+      publicKey: account.id,
+      balances,
+    };
+  } catch (error: any) {
+    if (error.response?.status === 404 || error.name === 'NotFoundError') {
+      return {
+        exists: false,
+        publicKey,
+        balances: [],
+      };
+    }
+
+    if (error.message?.includes('invalid')) {
+      throw new Error('Invalid Stellar Public Key format');
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
- Adds a read-only endpoint to verify a DJ’s Stellar account before payments
- Ensures the account exists and is funded using Horizon

closes #59 