### PR TITLE
feat: add payment service to handle XLM transactions with fee 

### DIFF
--- a/apps/stellar-service/src/config/stellar.ts
+++ b/apps/stellar-service/src/config/stellar.ts
@@ -26,3 +26,7 @@ export const getNetworkConfig = () => ({
   horizonUrl: process.env.STELLAR_HORIZON_URL,
   publicKey: serverKeypair.publicKey(),
 });
+
+export const PLATFORM_FEE = Number(process.env.PLATFORM_FEE_PERCENT || 0.1);
+export const TREASURY_KEY =
+  process.env.TREASURY_PUB_KEY || serverKeypair.publicKey();

--- a/apps/stellar-service/src/services/payment.service.ts
+++ b/apps/stellar-service/src/services/payment.service.ts
@@ -1,0 +1,50 @@
+import { Operation } from '@stellar/stellar-sdk';
+import { buildAndSubmitTx } from './transaction.service';
+import { checkAccount } from './account.service';
+import { PLATFORM_FEE, TREASURY_KEY } from '../config/stellar';
+
+export const sendPayment = async (
+  destination: string,
+  amountStr: string,
+  memo?: string,
+) => {
+  console.log(`💸 Processing Payment: ${amountStr} XLM -> ${destination}`);
+
+  const recipient = await checkAccount(destination);
+  if (!recipient.exists) {
+    throw new Error('❌ Recipient account does not exist.');
+  }
+
+  const totalAmount = Number(amountStr);
+  const feeAmount = totalAmount * PLATFORM_FEE;
+  const payoutAmount = totalAmount - feeAmount;
+
+  const feeString = feeAmount.toFixed(7);
+  const payoutString = payoutAmount.toFixed(7);
+
+  console.log(
+    `   🧾 Split: DJ gets ${payoutString} | Platform gets ${feeString}`,
+  );
+
+  const operations = [];
+
+  operations.push(
+    Operation.payment({
+      destination: destination,
+      asset: undefined as any,
+      amount: payoutString,
+    }),
+  );
+
+  if (feeAmount > 0) {
+    operations.push(
+      Operation.payment({
+        destination: TREASURY_KEY,
+        asset: undefined as any,
+        amount: feeString,
+      }),
+    );
+  }
+
+  return await buildAndSubmitTx(operations, memo);
+};


### PR DESCRIPTION
## Summary

Automatically deduct MixMatch’s platform fee during direct payments by splitting funds atomically within a single Stellar transaction.

## What’s Changed

* Extended the direct payment flow to support atomic fee splitting
* Each transaction now includes:

  * Payment to DJ (e.g. 90%)
  * Payment to MixMatch treasury (e.g. 10%)
* Platform fee percentage is configurable
* Treasury address is resolved via environment configuration

## Why

* Ensures platform fees are always collected
* Prevents partial payments or inconsistent state
* Centralizes fee logic for reuse across escrow and subscription flows

closes #61 
