### PR TITLE
Add auth register route and controller

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,8 @@
     "dotenv": "^17.2.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.3",
-    "mongoose": "^9.1.5"
+    "mongoose": "^9.1.5",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@mixmatch/config": "workspace:*",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,12 +1,14 @@
 import express from 'express';
 import cors from 'cors';
 import connectDB from './config/db';
+import authRouter from './modules/auth/auth.routes';
 
 const app = express();
 const port = process.env.PORT || 3001;
 
 app.use(cors());
 app.use(express.json());
+app.use('/auth', authRouter);
 
 connectDB();
 

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,0 +1,70 @@
+import { Request, Response } from 'express';
+import bcrypt from 'bcryptjs';
+import User from '../users/user.model';
+import { generateToken } from '../../services/jwt.service';
+import { registerSchema } from './auth.validation';
+
+const SALT_ROUNDS = 10;
+
+const deriveNameFromEmail = (email: string): string => {
+  const localPart = email.split('@')[0] || 'mixmatch-user';
+  return localPart.trim() || 'mixmatch-user';
+};
+
+export const register = async (req: Request, res: Response): Promise<void> => {
+  const parsedPayload = registerSchema.safeParse(req.body);
+
+  if (!parsedPayload.success) {
+    res.status(400).json({
+      message: 'Validation failed',
+      errors: parsedPayload.error.flatten(),
+    });
+    return;
+  }
+
+  const { email, password, role } = parsedPayload.data;
+
+  try {
+    const normalizedEmail = email.toLowerCase();
+    const existingUser = await User.findOne({ email: normalizedEmail }).lean();
+
+    if (existingUser) {
+      res.status(409).json({ message: 'Email is already registered' });
+      return;
+    }
+
+    const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+
+    const createdUser = await User.create({
+      name: deriveNameFromEmail(normalizedEmail),
+      email: normalizedEmail,
+      passwordHash,
+      role,
+      onboardingCompleted: false,
+    });
+
+    const token = generateToken(createdUser.id, createdUser.role);
+
+    res.status(201).json({
+      token,
+      user: {
+        id: createdUser.id,
+        name: createdUser.name,
+        email: createdUser.email,
+        role: createdUser.role,
+        onboardingCompleted: createdUser.onboardingCompleted,
+        createdAt: createdUser.createdAt,
+        updatedAt: createdUser.updatedAt,
+      },
+    });
+  } catch (error) {
+    const maybeMongoError = error as { code?: number };
+
+    if (maybeMongoError.code === 11000) {
+      res.status(409).json({ message: 'Email is already registered' });
+      return;
+    }
+
+    res.status(500).json({ message: 'Internal server error' });
+  }
+};

--- a/apps/api/src/modules/auth/auth.routes.ts
+++ b/apps/api/src/modules/auth/auth.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { register } from './auth.controller';
+
+const authRouter = Router();
+
+authRouter.post('/register', register);
+
+export default authRouter;

--- a/apps/api/src/modules/auth/auth.validation.ts
+++ b/apps/api/src/modules/auth/auth.validation.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { UserRole } from '@mixmatch/types';
+
+export const registerSchema = z.object({
+  email: z.string().trim().email(),
+  password: z.string().min(8, 'Password must be at least 8 characters long'),
+  role: z.enum([UserRole.DJ, UserRole.PLANNER, UserRole.MUSIC_LOVER]),
+});
+
+export type RegisterInput = z.infer<typeof registerSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       mongoose:
         specifier: ^9.1.5
         version: 9.1.5
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@mixmatch/config':
         specifier: workspace:*


### PR DESCRIPTION
Introduce a new auth module: adds POST /auth/register route, a controller that validates input with zod, checks for existing users, hashes passwords with bcrypt, creates a user, and returns a JWT and user payload. Wires the auth router into the app entry (index.ts) and adds zod as a dependency. Validation enforces email, password (min 8 chars) and role (UserRole enum); controller handles duplicate email and generic server errors.
closes #76