### PR TITLE
feat(mobile): scaffold Expo workspace, navigation stacks, session layer, and discovery adapter

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_URL=http://localhost:3001

--- a/apps/mobile/app.tsx
+++ b/apps/mobile/app.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect } from 'react';
+import { bootstrapSession } from '@/store/session.store';
+import { RootNavigator } from '@/navigation/RootNavigator';
+
+export default function App() {
+  useEffect(() => {
+    bootstrapSession();
+  }, []);
+
+  return <RootNavigator />;
+}

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/apps/mobile/docs/adr-001-expo-managed.md
+++ b/apps/mobile/docs/adr-001-expo-managed.md
@@ -1,0 +1,28 @@
+# ADR-001: Use Expo (Managed Workflow) for the Mobile App
+
+**Date:** 2026-04-24  
+**Status:** Accepted
+
+## Context
+
+The MixMatch monorepo already uses pnpm workspaces and TurboRepo. We need a mobile
+workspace that contributors can run locally without native toolchain setup, and that
+can share `@mixmatch/types` without path hacks.
+
+## Decision
+
+Use **Expo SDK 51 (managed workflow)** with `expo-router` for file-based navigation.
+
+Reasons:
+- Zero native toolchain required for JS contributors (`expo start` / Expo Go).
+- `expo-secure-store` provides encrypted on-device token storage (replaces
+  `localStorage` pattern used on web).
+- `expo-constants` gives a clean env-var bridge (`EXPO_PUBLIC_*`) consistent with
+  Next.js `NEXT_PUBLIC_*` convention.
+- Managed workflow keeps the monorepo free of `ios/` and `android/` directories
+  until native modules require ejecting.
+
+## Consequences
+
+- Native modules beyond the Expo SDK require `expo prebuild` (eject to bare).
+- Expo SDK version pins React Native; upgrading Expo upgrades RN transitively.

--- a/apps/mobile/eslint.config.mjs
+++ b/apps/mobile/eslint.config.mjs
@@ -1,0 +1,11 @@
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: { parser: tsParser },
+    rules: {
+      'no-console': 'warn',
+    },
+  },
+];

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "mobile",
+  "version": "0.0.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "dev": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@mixmatch/types": "workspace:*",
+    "@react-navigation/native": "^6.1.18",
+    "@react-navigation/native-stack": "^6.11.0",
+    "@react-navigation/bottom-tabs": "^6.6.1",
+    "expo": "~51.0.0",
+    "expo-constants": "~16.0.0",
+    "expo-linking": "~6.3.0",
+    "expo-router": "~3.5.0",
+    "expo-secure-store": "~13.0.0",
+    "expo-status-bar": "~1.12.0",
+    "react": "18.2.0",
+    "react-native": "0.74.0",
+    "react-native-safe-area-context": "4.10.1",
+    "react-native-screens": "3.31.1",
+    "zustand": "^4.5.0"
+  },
+  "devDependencies": {
+    "@mixmatch/config": "workspace:*",
+    "@babel/core": "^7.24.0",
+    "@types/react": "~18.2.0",
+    "@types/react-native": "~0.73.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/apps/mobile/src/features/discovery/discovery.types.ts
+++ b/apps/mobile/src/features/discovery/discovery.types.ts
@@ -1,0 +1,18 @@
+import type { DjGenre, AvailabilityStatus, DjDiscoveryItemDto } from '@mixmatch/types';
+
+export type DiscoveryMode = 'normal' | 'blind';
+
+export interface DiscoveryFilters {
+  q?: string;
+  genre?: DjGenre;
+  availabilityStatus?: AvailabilityStatus;
+  minPrice?: number;
+  maxPrice?: number;
+  mode?: DiscoveryMode;
+}
+
+export interface DiscoveryPage {
+  items: DjDiscoveryItemDto[];
+  nextCursor: string | null;
+  total: number;
+}

--- a/apps/mobile/src/features/discovery/discoveryAdapter.ts
+++ b/apps/mobile/src/features/discovery/discoveryAdapter.ts
@@ -1,0 +1,64 @@
+import type { PaginatedResponseDto } from '@mixmatch/types';
+import { apiRequest } from '@/lib/apiClient';
+import { useSessionStore } from '@/store/session.store';
+import type { DiscoveryFilters, DiscoveryPage } from './discovery.types';
+
+const PAGE_SIZE = 20;
+
+/** Decode an opaque cursor back to a page number (1-based). */
+function decodeCursor(cursor: string | null): number {
+  if (!cursor) return 1;
+  try {
+    return parseInt(atob(cursor), 10) || 1;
+  } catch {
+    return 1;
+  }
+}
+
+/** Encode a page number into an opaque cursor string. */
+function encodeCursor(page: number): string {
+  return btoa(String(page));
+}
+
+/**
+ * Fetch one page of discovery results.
+ *
+ * @param cursor  Opaque cursor from the previous page (null = first page).
+ * @param filters Surface / mode filters.
+ * @param signal  AbortSignal — pass a new one on each rapid gesture to cancel stale requests.
+ */
+export async function fetchDiscoveryPage(
+  cursor: string | null,
+  filters: DiscoveryFilters,
+  signal?: AbortSignal,
+): Promise<DiscoveryPage> {
+  const token = useSessionStore.getState().token;
+  const page = decodeCursor(cursor);
+
+  const params = new URLSearchParams({
+    page: String(page),
+    pageSize: String(PAGE_SIZE),
+  });
+
+  if (filters.q) params.set('q', filters.q);
+  if (filters.genre) params.set('genre', filters.genre);
+  if (filters.availabilityStatus) params.set('availabilityStatus', filters.availabilityStatus);
+  if (filters.minPrice !== undefined) params.set('minPrice', String(filters.minPrice));
+  if (filters.maxPrice !== undefined) params.set('maxPrice', String(filters.maxPrice));
+  // blind-mode flag — server can use this to strip identifying info
+  if (filters.mode === 'blind') params.set('blind', '1');
+
+  const data = await apiRequest<PaginatedResponseDto<ReturnType<typeof Object.create>>>(
+    `/discovery/djs?${params.toString()}`,
+    { token, signal },
+  );
+
+  const hasMore = page * PAGE_SIZE < data.total;
+  const nextCursor = hasMore ? encodeCursor(page + 1) : null;
+
+  return {
+    items: data.items,
+    nextCursor,
+    total: data.total,
+  };
+}

--- a/apps/mobile/src/features/discovery/useDiscoveryFeed.ts
+++ b/apps/mobile/src/features/discovery/useDiscoveryFeed.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { DjDiscoveryItemDto } from '@mixmatch/types';
+import { fetchDiscoveryPage } from './discoveryAdapter';
+import type { DiscoveryFilters } from './discovery.types';
+
+interface FeedState {
+  items: DjDiscoveryItemDto[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  error: Error | null;
+  hasMore: boolean;
+}
+
+/**
+ * Manages a paginated discovery feed with:
+ * - cursor-based pagination (loadMore)
+ * - automatic cursor reset when filters change
+ * - AbortController cancellation on rapid filter changes
+ */
+export function useDiscoveryFeed(filters: DiscoveryFilters) {
+  const [state, setState] = useState<FeedState>({
+    items: [],
+    isLoading: true,
+    isLoadingMore: false,
+    error: null,
+    hasMore: false,
+  });
+
+  const cursorRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const load = useCallback(
+    async (reset: boolean) => {
+      // Cancel any in-flight request
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      if (reset) {
+        cursorRef.current = null;
+        setState((s) => ({ ...s, isLoading: true, error: null }));
+      } else {
+        setState((s) => ({ ...s, isLoadingMore: true, error: null }));
+      }
+
+      try {
+        const page = await fetchDiscoveryPage(
+          cursorRef.current,
+          filters,
+          controller.signal,
+        );
+
+        cursorRef.current = page.nextCursor;
+
+        setState((s) => ({
+          items: reset ? page.items : [...s.items, ...page.items],
+          isLoading: false,
+          isLoadingMore: false,
+          error: null,
+          hasMore: page.nextCursor !== null,
+        }));
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return; // stale — ignore
+        setState((s) => ({
+          ...s,
+          isLoading: false,
+          isLoadingMore: false,
+          error: err as Error,
+        }));
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(filters)],
+  );
+
+  // Reset and reload whenever filters change
+  useEffect(() => {
+    load(true);
+    return () => abortRef.current?.abort();
+  }, [load]);
+
+  const loadMore = useCallback(() => {
+    if (!state.hasMore || state.isLoadingMore) return;
+    load(false);
+  }, [load, state.hasMore, state.isLoadingMore]);
+
+  return { ...state, loadMore };
+}

--- a/apps/mobile/src/lib/apiClient.ts
+++ b/apps/mobile/src/lib/apiClient.ts
@@ -1,0 +1,50 @@
+import { env } from './env';
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+interface RequestOptions extends Omit<RequestInit, 'body'> {
+  body?: unknown;
+  token?: string | null;
+}
+
+export async function apiRequest<T>(
+  path: string,
+  options: RequestOptions = {},
+): Promise<T> {
+  const { body, headers, token, signal, ...rest } = options;
+
+  const res = await fetch(`${env.apiUrl}${path}`, {
+    ...rest,
+    signal,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(headers as Record<string, string>),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  const payload = (await res.json().catch(() => null)) as {
+    message?: string;
+    error?: { message?: string; details?: unknown };
+  } | null;
+
+  if (!res.ok) {
+    throw new ApiError(
+      payload?.error?.message ?? payload?.message ?? 'Request failed',
+      res.status,
+      payload?.error?.details,
+    );
+  }
+
+  return payload as T;
+}

--- a/apps/mobile/src/lib/env.ts
+++ b/apps/mobile/src/lib/env.ts
@@ -1,0 +1,16 @@
+import Constants from 'expo-constants';
+
+const extra = (Constants.expoConfig?.extra ?? {}) as Record<string, unknown>;
+
+const get = (key: string, fallback?: string): string => {
+  const val =
+    (process.env[key] as string | undefined) ??
+    (extra[key] as string | undefined) ??
+    fallback;
+  if (!val) throw new Error(`Missing env var: ${key}`);
+  return val;
+};
+
+export const env = {
+  apiUrl: get('EXPO_PUBLIC_API_URL', 'http://localhost:3001'),
+};

--- a/apps/mobile/src/lib/tokenStorage.ts
+++ b/apps/mobile/src/lib/tokenStorage.ts
@@ -1,0 +1,15 @@
+import * as SecureStore from 'expo-secure-store';
+
+const TOKEN_KEY = 'mixmatch.auth.token';
+
+export const tokenStorage = {
+  async get(): Promise<string | null> {
+    return SecureStore.getItemAsync(TOKEN_KEY);
+  },
+  async set(token: string): Promise<void> {
+    await SecureStore.setItemAsync(TOKEN_KEY, token);
+  },
+  async clear(): Promise<void> {
+    await SecureStore.deleteItemAsync(TOKEN_KEY);
+  },
+};

--- a/apps/mobile/src/navigation/AuthStack.tsx
+++ b/apps/mobile/src/navigation/AuthStack.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { AuthStackParamList } from './types';
+import { LoginScreen } from '@/screens/auth/LoginScreen';
+import { RegisterScreen } from '@/screens/auth/RegisterScreen';
+
+const Stack = createNativeStackNavigator<AuthStackParamList>();
+
+export function AuthStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Login" component={LoginScreen} />
+      <Stack.Screen name="Register" component={RegisterScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/apps/mobile/src/navigation/MainTabs.tsx
+++ b/apps/mobile/src/navigation/MainTabs.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import type { MainTabParamList } from './types';
+import { DiscoveryScreen } from '@/screens/main/DiscoveryScreen';
+import { BlindModeScreen } from '@/screens/main/BlindModeScreen';
+import { ResonancesScreen } from '@/screens/main/ResonancesScreen';
+import { MessagesScreen } from '@/screens/main/MessagesScreen';
+import { EventsScreen } from '@/screens/main/EventsScreen';
+import { SettingsScreen } from '@/screens/main/SettingsScreen';
+
+const Tab = createBottomTabNavigator<MainTabParamList>();
+
+export function MainTabs() {
+  return (
+    <Tab.Navigator screenOptions={{ headerShown: false }}>
+      <Tab.Screen name="Discovery" component={DiscoveryScreen} />
+      <Tab.Screen name="BlindMode" component={BlindModeScreen} />
+      <Tab.Screen name="Resonances" component={ResonancesScreen} />
+      <Tab.Screen name="Messages" component={MessagesScreen} />
+      <Tab.Screen name="Events" component={EventsScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
+    </Tab.Navigator>
+  );
+}

--- a/apps/mobile/src/navigation/OnboardingStack.tsx
+++ b/apps/mobile/src/navigation/OnboardingStack.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { OnboardingStackParamList } from './types';
+import { OnboardingWelcomeScreen } from '@/screens/onboarding/OnboardingWelcomeScreen';
+import { OnboardingProfileScreen } from '@/screens/onboarding/OnboardingProfileScreen';
+
+const Stack = createNativeStackNavigator<OnboardingStackParamList>();
+
+export function OnboardingStack() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="OnboardingWelcome" component={OnboardingWelcomeScreen} />
+      <Stack.Screen name="OnboardingProfile" component={OnboardingProfileScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import * as Linking from 'expo-linking';
+import type { RootStackParamList } from './types';
+import { AuthStack } from './AuthStack';
+import { OnboardingStack } from './OnboardingStack';
+import { MainTabs } from './MainTabs';
+import { NotificationScreen } from '@/screens/deeplink/NotificationScreen';
+import { SharedTrackScreen } from '@/screens/deeplink/SharedTrackScreen';
+import { useSessionStore } from '@/store/session.store';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const prefix = Linking.createURL('/');
+
+const linking = {
+  prefixes: [prefix, 'mixmatch://'],
+  config: {
+    screens: {
+      Main: {
+        screens: {
+          Discovery: 'discovery',
+          BlindMode: 'blind',
+          Resonances: 'resonances',
+          Messages: 'messages',
+          Events: 'events',
+          Settings: 'settings',
+        },
+      },
+      Notification: 'notification/:notificationId',
+      SharedTrack: 'track/:trackId',
+    },
+  },
+};
+
+export function RootNavigator() {
+  const { user, isHydrated } = useSessionStore();
+
+  if (!isHydrated) return null;
+
+  const initialRoute: keyof RootStackParamList = !user
+    ? 'Auth'
+    : !user.onboardingCompleted
+      ? 'Onboarding'
+      : 'Main';
+
+  return (
+    <NavigationContainer linking={linking}>
+      <Stack.Navigator
+        initialRouteName={initialRoute}
+        screenOptions={{ headerShown: false }}
+      >
+        <Stack.Screen name="Auth" component={AuthStack} />
+        <Stack.Screen name="Onboarding" component={OnboardingStack} />
+        <Stack.Screen name="Main" component={MainTabs} />
+        {/* Deep-link targets */}
+        <Stack.Screen name="Notification" component={NotificationScreen} />
+        <Stack.Screen name="SharedTrack" component={SharedTrackScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -1,0 +1,44 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
+
+// ── Auth stack ────────────────────────────────────────────────────────────────
+export type AuthStackParamList = {
+  Login: undefined;
+  Register: undefined;
+};
+
+// ── Onboarding stack ──────────────────────────────────────────────────────────
+export type OnboardingStackParamList = {
+  OnboardingWelcome: undefined;
+  OnboardingProfile: undefined;
+};
+
+// ── Main tab navigator ────────────────────────────────────────────────────────
+export type MainTabParamList = {
+  Discovery: undefined;
+  BlindMode: undefined;
+  Resonances: undefined;
+  Messages: undefined;
+  Events: undefined;
+  Settings: undefined;
+};
+
+// ── Root stack (wraps everything) ─────────────────────────────────────────────
+export type RootStackParamList = {
+  Auth: undefined;
+  Onboarding: undefined;
+  Main: undefined;
+  // Deep-link placeholders
+  Notification: { notificationId: string };
+  SharedTrack: { trackId: string };
+};
+
+// Convenience prop types
+export type AuthScreenProps<T extends keyof AuthStackParamList> =
+  NativeStackScreenProps<AuthStackParamList, T>;
+
+export type OnboardingScreenProps<T extends keyof OnboardingStackParamList> =
+  NativeStackScreenProps<OnboardingStackParamList, T>;
+
+export type MainTabScreenProps<T extends keyof MainTabParamList> =
+  BottomTabScreenProps<MainTabParamList, T>;

--- a/apps/mobile/src/screens/_placeholder.tsx
+++ b/apps/mobile/src/screens/_placeholder.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export function placeholder(name: string) {
+  return function PlaceholderScreen() {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.text}>{name}</Text>
+      </View>
+    );
+  };
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  text: { fontSize: 18, color: '#888' },
+});

--- a/apps/mobile/src/screens/auth/LoginScreen.tsx
+++ b/apps/mobile/src/screens/auth/LoginScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const LoginScreen = placeholder('Login');

--- a/apps/mobile/src/screens/auth/RegisterScreen.tsx
+++ b/apps/mobile/src/screens/auth/RegisterScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const RegisterScreen = placeholder('Register');

--- a/apps/mobile/src/screens/deeplink/NotificationScreen.tsx
+++ b/apps/mobile/src/screens/deeplink/NotificationScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const NotificationScreen = placeholder('Notification');

--- a/apps/mobile/src/screens/deeplink/SharedTrackScreen.tsx
+++ b/apps/mobile/src/screens/deeplink/SharedTrackScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const SharedTrackScreen = placeholder('Shared Track');

--- a/apps/mobile/src/screens/main/BlindModeScreen.tsx
+++ b/apps/mobile/src/screens/main/BlindModeScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const BlindModeScreen = placeholder('BlindMode');

--- a/apps/mobile/src/screens/main/DiscoveryScreen.tsx
+++ b/apps/mobile/src/screens/main/DiscoveryScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const DiscoveryScreen = placeholder('Discovery');

--- a/apps/mobile/src/screens/main/EventsScreen.tsx
+++ b/apps/mobile/src/screens/main/EventsScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const EventsScreen = placeholder('Events');

--- a/apps/mobile/src/screens/main/MessagesScreen.tsx
+++ b/apps/mobile/src/screens/main/MessagesScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const MessagesScreen = placeholder('Messages');

--- a/apps/mobile/src/screens/main/ResonancesScreen.tsx
+++ b/apps/mobile/src/screens/main/ResonancesScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const ResonancesScreen = placeholder('Resonances');

--- a/apps/mobile/src/screens/main/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/main/SettingsScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const SettingsScreen = placeholder('Settings');

--- a/apps/mobile/src/screens/onboarding/OnboardingProfileScreen.tsx
+++ b/apps/mobile/src/screens/onboarding/OnboardingProfileScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const OnboardingProfileScreen = placeholder('Onboarding — Profile');

--- a/apps/mobile/src/screens/onboarding/OnboardingWelcomeScreen.tsx
+++ b/apps/mobile/src/screens/onboarding/OnboardingWelcomeScreen.tsx
@@ -1,0 +1,2 @@
+import { placeholder } from '../_placeholder';
+export const OnboardingWelcomeScreen = placeholder('Onboarding — Welcome');

--- a/apps/mobile/src/store/session.store.ts
+++ b/apps/mobile/src/store/session.store.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand';
+import type { IUser } from '@mixmatch/types';
+import { tokenStorage } from '@/lib/tokenStorage';
+import { apiRequest } from '@/lib/apiClient';
+
+interface SessionState {
+  user: IUser | null;
+  token: string | null;
+  isHydrated: boolean;
+  isAuthenticated: boolean;
+}
+
+interface SessionActions {
+  /** Restore token from secure storage and re-fetch /auth/me */
+  bootstrap: () => Promise<void>;
+  login: (token: string, user: IUser) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+export const useSessionStore = create<SessionState & SessionActions>((set, get) => ({
+  user: null,
+  token: null,
+  isHydrated: false,
+  isAuthenticated: false,
+
+  async bootstrap() {
+    const token = await tokenStorage.get();
+    if (!token) {
+      set({ isHydrated: true });
+      return;
+    }
+    try {
+      const { user } = await apiRequest<{ user: IUser }>('/auth/me', { token });
+      set({ user, token, isAuthenticated: true, isHydrated: true });
+    } catch {
+      // Token invalid / expired — clear it
+      await tokenStorage.clear();
+      set({ isHydrated: true });
+    }
+  },
+
+  async login(token, user) {
+    await tokenStorage.set(token);
+    set({ token, user, isAuthenticated: true });
+  },
+
+  async logout() {
+    await tokenStorage.clear();
+    set({ user: null, token: null, isAuthenticated: false });
+  },
+}));
+
+/** Call once at app startup (e.g. in app.tsx or a bootstrap effect). */
+export function bootstrapSession() {
+  return useSessionStore.getState().bootstrap();
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@mixmatch/config/base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "jsx": "react-native",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src", "app.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

This PR implements all four mobile foundation issues assigned to @Tinna23 in Sprint 1.

---

### Closes #211 — React Native (Expo) workspace scaffold

- `apps/mobile/package.json` — Expo 51, react-navigation, zustand, `@mixmatch/types` workspace dep
- `tsconfig.json` extending `@mixmatch/config/base.json` with `react-native` jsx
- `babel.config.js`, `eslint.config.mjs`, `.env.example`
- `src/lib/env.ts` — `EXPO_PUBLIC_API_URL` bridge (mirrors `NEXT_PUBLIC_*` convention)
- `docs/adr-001-expo-managed.md` — rationale for Expo managed workflow

### Closes #212 — Navigation stacks for auth and product areas

- `src/navigation/types.ts` — typed param lists for all stacks/tabs
- `AuthStack`, `OnboardingStack`, `MainTabs` (Discovery, BlindMode, Resonances, Messages, Events, Settings)
- `RootNavigator` — gates on session hydration, deep-link config for `mixmatch://` scheme
- Deep-link placeholders: `notification/:notificationId`, `track/:trackId`
- Placeholder screens for every registered route

### Closes #213 — Session bootstrap and secure token storage

- `src/lib/tokenStorage.ts` — `expo-secure-store` get/set/clear (no localStorage)
- `src/lib/apiClient.ts` — typed fetch wrapper with `AbortSignal` + Bearer auth; shared by realtime and provider APIs
- `src/store/session.store.ts` — zustand store: `bootstrap` (restore token → `/auth/me`), `login`, `logout` (clears all cached auth artifacts)
- `app.tsx` calls `bootstrapSession()` on mount; `RootNavigator` waits for `isHydrated`

### Closes #214 — Mobile discovery feed query adapter

- `src/features/discovery/discovery.types.ts` — `DiscoveryFilters`, `DiscoveryPage`, `DiscoveryMode`
- `src/features/discovery/discoveryAdapter.ts` — cursor pagination (opaque base64 cursor over page numbers), blind-mode flag, `AbortController` cancellation
- `src/features/discovery/useDiscoveryFeed.ts` — React hook: resets cursor on filter change, `loadMore`, cancels stale requests on rapid gesture changes

---

### Workspace config

`pnpm-workspace.yaml` already covers `apps/*` so no changes needed. `turbo.json` tasks are generic and apply to the mobile workspace automatically.