### PR TITLE
feat: domain models for resonance, conversation, shared-frequency & chemistry-event (#187–#190)

### DIFF
--- a/apps/api/src/modules/chemistry-event/chemistry-event.model.ts
+++ b/apps/api/src/modules/chemistry-event/chemistry-event.model.ts
@@ -1,0 +1,109 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export enum EventVariant {
+  LIVE = 'LIVE',
+  ASYNC = 'ASYNC',
+}
+
+export enum ChemistryEventStatus {
+  SCHEDULED = 'SCHEDULED',
+  ACTIVE = 'ACTIVE',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+}
+
+export enum ParticipationState {
+  JOINED = 'JOINED',
+  LEFT = 'LEFT',
+  COMPLETED = 'COMPLETED',
+  REMOVED = 'REMOVED',
+}
+
+export enum PoolSegment {
+  GENERAL = 'GENERAL',
+  VIP = 'VIP',
+  EARLY_ACCESS = 'EARLY_ACCESS',
+}
+
+export interface IParticipant {
+  _id?: mongoose.Types.ObjectId;
+  user: mongoose.Types.ObjectId;
+  segment: PoolSegment;
+  state: ParticipationState;
+  joinedAt: Date;
+  leftAt?: Date;
+  progressionScore?: number;
+}
+
+export interface IChemistryEventDocument extends Document {
+  title: string;
+  theme: string;
+  variant: EventVariant;
+  status: ChemistryEventStatus;
+  windowStart: Date;
+  windowEnd: Date;
+  capacityLimit?: number;
+  entryConstraints: string[];
+  poolSegmentRules: string[];
+  moderationFlagged: boolean;
+  participants: IParticipant[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ParticipantSchema = new Schema<IParticipant>(
+  {
+    user: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    segment: {
+      type: String,
+      enum: Object.values(PoolSegment),
+      default: PoolSegment.GENERAL,
+    },
+    state: {
+      type: String,
+      enum: Object.values(ParticipationState),
+      default: ParticipationState.JOINED,
+    },
+    joinedAt: { type: Date, default: Date.now },
+    leftAt: { type: Date },
+    progressionScore: { type: Number, min: 0 },
+  },
+  { _id: true },
+);
+
+const ChemistryEventSchema = new Schema<IChemistryEventDocument>(
+  {
+    title: { type: String, required: true, trim: true, maxlength: 200 },
+    theme: { type: String, required: true, trim: true, maxlength: 200 },
+    variant: {
+      type: String,
+      enum: Object.values(EventVariant),
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: Object.values(ChemistryEventStatus),
+      default: ChemistryEventStatus.SCHEDULED,
+      index: true,
+    },
+    windowStart: { type: Date, required: true, index: true },
+    windowEnd: { type: Date, required: true, index: true },
+    capacityLimit: { type: Number, min: 1 },
+    entryConstraints: { type: [String], default: [] },
+    poolSegmentRules: { type: [String], default: [] },
+    moderationFlagged: { type: Boolean, default: false, index: true },
+    participants: { type: [ParticipantSchema], default: [] },
+  },
+  { timestamps: true },
+);
+
+// Active-event lookup (index-backed per acceptance criteria)
+ChemistryEventSchema.index({ status: 1, windowStart: 1, windowEnd: 1 });
+// Participant lookup across events
+ChemistryEventSchema.index({ 'participants.user': 1, 'participants.state': 1 });
+
+const ChemistryEvent = mongoose.model<IChemistryEventDocument>(
+  'ChemistryEvent',
+  ChemistryEventSchema,
+);
+export default ChemistryEvent;

--- a/apps/api/src/modules/conversation/conversation.model.ts
+++ b/apps/api/src/modules/conversation/conversation.model.ts
@@ -1,0 +1,109 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export enum ThreadPhase {
+  MUSIC_ONLY = 'MUSIC_ONLY',
+  TEXT_UNLOCKED = 'TEXT_UNLOCKED',
+}
+
+export enum MessageType {
+  TRACK_SHARE = 'TRACK_SHARE',
+  REACTION = 'REACTION',
+  UNLOCK_EVENT = 'UNLOCK_EVENT',
+  TEXT = 'TEXT',
+  ATTACHMENT = 'ATTACHMENT',
+}
+
+export interface IParticipantReadState {
+  participant: mongoose.Types.ObjectId;
+  lastReadAt: Date;
+}
+
+export interface IMessage {
+  _id?: mongoose.Types.ObjectId;
+  sender: mongoose.Types.ObjectId;
+  type: MessageType;
+  body?: string;
+  trackRef?: string;       // external track ID / URI
+  reactionEmoji?: string;
+  attachmentUrl?: string;
+  moderationFlagged: boolean;
+  createdAt: Date;
+}
+
+export interface IConversationDocument extends Document {
+  resonance: mongoose.Types.ObjectId;
+  participants: mongoose.Types.ObjectId[];
+  phase: ThreadPhase;
+  messages: IMessage[];
+  readState: IParticipantReadState[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const MessageSchema = new Schema<IMessage>(
+  {
+    sender: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    type: { type: String, enum: Object.values(MessageType), required: true },
+    body: { type: String, trim: true, maxlength: 4000 },
+    trackRef: { type: String, trim: true },
+    reactionEmoji: { type: String, trim: true, maxlength: 10 },
+    attachmentUrl: { type: String, trim: true },
+    moderationFlagged: { type: Boolean, default: false },
+  },
+  { timestamps: { createdAt: true, updatedAt: false }, _id: true },
+);
+
+const ParticipantReadStateSchema = new Schema<IParticipantReadState>(
+  {
+    participant: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    lastReadAt: { type: Date, required: true },
+  },
+  { _id: false },
+);
+
+const ConversationSchema = new Schema<IConversationDocument>(
+  {
+    resonance: {
+      type: Schema.Types.ObjectId,
+      ref: 'Resonance',
+      required: true,
+      unique: true,
+      immutable: true,
+    },
+    participants: {
+      type: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+      required: true,
+      validate: {
+        validator: (v: mongoose.Types.ObjectId[]) => v.length === 2,
+        message: 'A conversation must have exactly 2 participants',
+      },
+    },
+    phase: {
+      type: String,
+      enum: Object.values(ThreadPhase),
+      default: ThreadPhase.MUSIC_ONLY,
+      index: true,
+    },
+    messages: { type: [MessageSchema], default: [] },
+    readState: { type: [ParticipantReadStateSchema], default: [] },
+  },
+  { timestamps: true },
+);
+
+// Guard: text messages are only allowed when phase is TEXT_UNLOCKED
+ConversationSchema.pre('save', function (next) {
+  if (this.isModified('messages')) {
+    const hasIllegalText = this.messages.some(
+      (m) => m.type === MessageType.TEXT && this.phase === ThreadPhase.MUSIC_ONLY,
+    );
+    if (hasIllegalText) {
+      return next(new Error('Text messages are not allowed before text unlock'));
+    }
+  }
+  next();
+});
+
+ConversationSchema.index({ participants: 1, phase: 1 });
+
+const Conversation = mongoose.model<IConversationDocument>('Conversation', ConversationSchema);
+export default Conversation;

--- a/apps/api/src/modules/resonance/resonance.model.ts
+++ b/apps/api/src/modules/resonance/resonance.model.ts
@@ -1,0 +1,111 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export enum ResonanceState {
+  PENDING_LIKE = 'PENDING_LIKE',
+  MUTUAL = 'MUTUAL',
+  REVEAL_REQUESTED = 'REVEAL_REQUESTED',
+  REVEALED = 'REVEALED',
+  TEXT_UNLOCKED = 'TEXT_UNLOCKED',
+  ARCHIVED = 'ARCHIVED',
+  BLOCKED = 'BLOCKED',
+}
+
+export enum ResonanceSurface {
+  DISCOVERY = 'DISCOVERY',
+  CHEMISTRY_EVENT = 'CHEMISTRY_EVENT',
+  SHARED_FREQUENCY = 'SHARED_FREQUENCY',
+}
+
+export enum LikeOrigin {
+  EARLY = 'EARLY',
+  FULL_JOURNEY = 'FULL_JOURNEY',
+}
+
+// Valid state transitions
+const VALID_TRANSITIONS: Record<ResonanceState, ResonanceState[]> = {
+  [ResonanceState.PENDING_LIKE]: [ResonanceState.MUTUAL, ResonanceState.ARCHIVED],
+  [ResonanceState.MUTUAL]: [ResonanceState.REVEAL_REQUESTED, ResonanceState.ARCHIVED],
+  [ResonanceState.REVEAL_REQUESTED]: [ResonanceState.REVEALED, ResonanceState.ARCHIVED],
+  [ResonanceState.REVEALED]: [ResonanceState.TEXT_UNLOCKED, ResonanceState.ARCHIVED],
+  [ResonanceState.TEXT_UNLOCKED]: [ResonanceState.ARCHIVED, ResonanceState.BLOCKED],
+  [ResonanceState.ARCHIVED]: [],
+  [ResonanceState.BLOCKED]: [],
+};
+
+export function isValidTransition(from: ResonanceState, to: ResonanceState): boolean {
+  return VALID_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+export interface IResonanceDocument extends Document {
+  initiator: mongoose.Types.ObjectId;
+  recipient: mongoose.Types.ObjectId;
+  state: ResonanceState;
+  surface: ResonanceSurface;
+  likeOrigin: LikeOrigin;
+  mutualAt?: Date;
+  revealRequestedAt?: Date;
+  revealedAt?: Date;
+  firstSongExchanged: boolean;
+  textUnlockedAt?: Date;
+  archivedAt?: Date;
+  blockedAt?: Date;
+  blockedBy?: mongoose.Types.ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ResonanceSchema = new Schema<IResonanceDocument>(
+  {
+    initiator: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+      immutable: true,
+    },
+    recipient: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+      immutable: true,
+    },
+    state: {
+      type: String,
+      enum: Object.values(ResonanceState),
+      default: ResonanceState.PENDING_LIKE,
+      index: true,
+    },
+    surface: {
+      type: String,
+      enum: Object.values(ResonanceSurface),
+      required: true,
+      immutable: true,
+    },
+    likeOrigin: {
+      type: String,
+      enum: Object.values(LikeOrigin),
+      required: true,
+      immutable: true,
+    },
+    mutualAt: { type: Date },
+    revealRequestedAt: { type: Date },
+    revealedAt: { type: Date },
+    firstSongExchanged: { type: Boolean, default: false },
+    textUnlockedAt: { type: Date },
+    archivedAt: { type: Date },
+    blockedAt: { type: Date },
+    blockedBy: { type: Schema.Types.ObjectId, ref: 'User' },
+  },
+  { timestamps: true },
+);
+
+// Unique pair constraint (one resonance per user pair)
+ResonanceSchema.index({ initiator: 1, recipient: 1 }, { unique: true });
+// Mutual resonance lookup (index-backed per acceptance criteria)
+ResonanceSchema.index({ state: 1, mutualAt: -1 });
+ResonanceSchema.index({ initiator: 1, state: 1 });
+ResonanceSchema.index({ recipient: 1, state: 1 });
+
+const Resonance = mongoose.model<IResonanceDocument>('Resonance', ResonanceSchema);
+export default Resonance;

--- a/apps/api/src/modules/shared-frequency/shared-frequency.model.ts
+++ b/apps/api/src/modules/shared-frequency/shared-frequency.model.ts
@@ -1,0 +1,112 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export enum PlaylistStatus {
+  ACTIVE = 'ACTIVE',
+  ARCHIVED = 'ARCHIVED',
+}
+
+export enum TrackProvenance {
+  ADDED = 'ADDED',
+  REORDERED = 'REORDERED',
+  PINNED = 'PINNED',
+  REMOVED = 'REMOVED',
+}
+
+export enum SyncStatus {
+  UNSYNCED = 'UNSYNCED',
+  SYNCED = 'SYNCED',
+  SYNC_ERROR = 'SYNC_ERROR',
+}
+
+export interface ITrackEntry {
+  _id?: mongoose.Types.ObjectId;
+  trackRef: string;       // external provider track ID / URI
+  provider: string;       // e.g. 'spotify', 'soundcloud'
+  addedBy: mongoose.Types.ObjectId;
+  position: number;
+  isPinnedMilestone: boolean;
+  addedAt: Date;
+}
+
+export interface IHistoryEvent {
+  _id?: mongoose.Types.ObjectId;
+  actor: mongoose.Types.ObjectId;
+  action: TrackProvenance;
+  trackRef: string;
+  position?: number;
+  occurredAt: Date;
+}
+
+export interface ISharedFrequencyDocument extends Document {
+  resonance: mongoose.Types.ObjectId;
+  contributors: mongoose.Types.ObjectId[];
+  tracks: ITrackEntry[];
+  history: IHistoryEvent[];
+  status: PlaylistStatus;
+  syncStatus: SyncStatus;
+  externalPlaylistId?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const TrackEntrySchema = new Schema<ITrackEntry>(
+  {
+    trackRef: { type: String, required: true, trim: true },
+    provider: { type: String, required: true, trim: true },
+    addedBy: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    position: { type: Number, required: true, min: 0 },
+    isPinnedMilestone: { type: Boolean, default: false },
+    addedAt: { type: Date, default: Date.now },
+  },
+  { _id: true },
+);
+
+const HistoryEventSchema = new Schema<IHistoryEvent>(
+  {
+    actor: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    action: { type: String, enum: Object.values(TrackProvenance), required: true },
+    trackRef: { type: String, required: true, trim: true },
+    position: { type: Number },
+    occurredAt: { type: Date, default: Date.now },
+  },
+  { _id: true },
+);
+
+const SharedFrequencySchema = new Schema<ISharedFrequencyDocument>(
+  {
+    resonance: {
+      type: Schema.Types.ObjectId,
+      ref: 'Resonance',
+      required: true,
+      unique: true,   // one playlist per resonance
+      immutable: true,
+    },
+    contributors: {
+      type: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+      default: [],
+    },
+    tracks: { type: [TrackEntrySchema], default: [] },
+    history: { type: [HistoryEventSchema], default: [] },
+    status: {
+      type: String,
+      enum: Object.values(PlaylistStatus),
+      default: PlaylistStatus.ACTIVE,
+      index: true,
+    },
+    syncStatus: {
+      type: String,
+      enum: Object.values(SyncStatus),
+      default: SyncStatus.UNSYNCED,
+    },
+    externalPlaylistId: { type: String, trim: true },
+  },
+  { timestamps: true },
+);
+
+SharedFrequencySchema.index({ contributors: 1, status: 1 });
+
+const SharedFrequency = mongoose.model<ISharedFrequencyDocument>(
+  'SharedFrequency',
+  SharedFrequencySchema,
+);
+export default SharedFrequency;


### PR DESCRIPTION
## Summary

closes #187
closes #188
closes #189
closes #190

Implements all four domain models assigned to BigBen-7 in Sprint 1 – Platform Foundation and Domain Reset.

---

### #187 – Model resonance state machine persistence
**File:** `apps/api/src/modules/resonance/resonance.model.ts`
- `ResonanceState` enum with full lifecycle: `PENDING_LIKE → MUTUAL → REVEAL_REQUESTED → REVEALED → TEXT_UNLOCKED → ARCHIVED / BLOCKED`
- `isValidTransition()` guard exported for use in repository methods
- Fields: `surface`, `likeOrigin` (EARLY / FULL_JOURNEY), mutual/reveal/text-unlock timestamps, `firstSongExchanged`, archive/block metadata
- Indexes: unique pair constraint, index-backed mutual resonance queries, per-user state lookups

### #188 – Model conversation thread and music-first unlock state
**File:** `apps/api/src/modules/conversation/conversation.model.ts`
- `ThreadPhase` state machine: `MUSIC_ONLY` → `TEXT_UNLOCKED`
- `MessageType` enum: `TRACK_SHARE`, `REACTION`, `UNLOCK_EVENT`, `TEXT`, `ATTACHMENT`
- Pre-save guard rejects `TEXT` messages while phase is `MUSIC_ONLY`
- Participant-scoped `readState` sub-document for future realtime delivery

### #189 – Model Shared Frequency collaborative playlist entity
**File:** `apps/api/src/modules/shared-frequency/shared-frequency.model.ts`
- One playlist per resonance (`unique` constraint on `resonance` field)
- Materialized `tracks` array with position ordering and `isPinnedMilestone` flag
- Append-only `history` events (`ADDED`, `REORDERED`, `PINNED`, `REMOVED`) for future timeline features
- `syncStatus` field for external provider sync state

### #190 – Create music chemistry event schema and participation model
**File:** `apps/api/src/modules/chemistry-event/chemistry-event.model.ts`
- `EventVariant`: `LIVE` / `ASYNC`
- `ChemistryEventStatus`: `SCHEDULED → ACTIVE → COMPLETED / CANCELLED`
- `ParticipationState`: `JOINED`, `LEFT`, `COMPLETED`, `REMOVED`
- `PoolSegment`: `GENERAL`, `VIP`, `EARLY_ACCESS`
- Capacity limit, entry constraints, pool segment rules, moderation flag
- Compound indexes for active-event window queries and participant lookups

---

Closes #187
Closes #188
Closes #189
Closes #190