### PR TITLE
feat(journeys): implement Vibe Journey domain API (issues #191-#194)

### DIFF
--- a/apps/api/src/domains/journeys/index.ts
+++ b/apps/api/src/domains/journeys/index.ts
@@ -1,1 +1,2 @@
 export { default as journeysRouter } from './bookings.routes';
+export { default as journeyRouter } from './journey.routes';

--- a/apps/api/src/domains/journeys/journey-snapshot.model.ts
+++ b/apps/api/src/domains/journeys/journey-snapshot.model.ts
@@ -1,0 +1,78 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export interface ISnapshotSlot {
+  order: number;
+  trackRef: string;
+  platform: string;
+  notes?: string;
+}
+
+export interface IJourneySnapshotDocument extends Document {
+  journeyId: mongoose.Types.ObjectId;
+  authorId: mongoose.Types.ObjectId;
+  title: string;
+  description?: string;
+  slots: ISnapshotSlot[];
+  draftVersion: number;
+  createdAt: Date;
+}
+
+const SnapshotSlotSchema = new Schema<ISnapshotSlot>(
+  {
+    order: { type: Number, required: true },
+    trackRef: { type: String, required: true, trim: true },
+    platform: { type: String, required: true, trim: true, lowercase: true },
+    notes: { type: String, trim: true },
+  },
+  { _id: false },
+);
+
+const JourneySnapshotSchema = new Schema<IJourneySnapshotDocument>(
+  {
+    journeyId: {
+      type: Schema.Types.ObjectId,
+      ref: 'VibeJourney',
+      required: true,
+      index: true,
+      immutable: true,
+    },
+    authorId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+      immutable: true,
+    },
+    title: {
+      type: String,
+      required: true,
+      trim: true,
+      immutable: true,
+    },
+    description: {
+      type: String,
+      trim: true,
+      immutable: true,
+    },
+    slots: {
+      type: [SnapshotSlotSchema],
+      required: true,
+      immutable: true,
+    },
+    draftVersion: {
+      type: Number,
+      required: true,
+      immutable: true,
+    },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: false },
+  },
+);
+
+// Unique constraint prevents duplicate snapshots for the same draft version
+JourneySnapshotSchema.index({ journeyId: 1, draftVersion: 1 }, { unique: true });
+
+const JourneySnapshot = mongoose.model<IJourneySnapshotDocument>('JourneySnapshot', JourneySnapshotSchema);
+
+export default JourneySnapshot;

--- a/apps/api/src/domains/journeys/journey.controller.ts
+++ b/apps/api/src/domains/journeys/journey.controller.ts
@@ -1,0 +1,157 @@
+import { Request, Response } from 'express';
+import { createDraftJourneySchema, updateSlotsSchema } from './journey.validation';
+import * as journeyService from './journey.service';
+import { IVibeJourneyDocument } from './vibe-journey.model';
+import { IJourneySnapshotDocument } from './journey-snapshot.model';
+
+const serializeJourney = (journey: IVibeJourneyDocument) => ({
+  id: String(journey._id),
+  author: String(journey.author),
+  title: journey.title,
+  description: journey.description,
+  status: journey.status,
+  slots: journey.slots,
+  version: journey.version,
+  latestPublishedSnapshotId: journey.latestPublishedSnapshotId
+    ? String(journey.latestPublishedSnapshotId)
+    : undefined,
+  createdAt: journey.createdAt,
+  updatedAt: journey.updatedAt,
+});
+
+const serializeSnapshot = (snapshot: IJourneySnapshotDocument) => ({
+  id: String(snapshot._id),
+  journeyId: String(snapshot.journeyId),
+  authorId: String(snapshot.authorId),
+  title: snapshot.title,
+  description: snapshot.description,
+  slots: snapshot.slots,
+  draftVersion: snapshot.draftVersion,
+  createdAt: snapshot.createdAt,
+});
+
+export const createDraftJourney = async (req: Request, res: Response): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ message: 'Unauthorized' });
+    return;
+  }
+
+  const parsed = createDraftJourneySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ message: 'Validation failed', errors: parsed.error.flatten() });
+    return;
+  }
+
+  try {
+    const { journey, created } = await journeyService.createOrReturnDraft(
+      req.user.userId,
+      parsed.data.title,
+      parsed.data.description,
+    );
+
+    res.status(created ? 201 : 200).json({ journey: serializeJourney(journey) });
+  } catch {
+    res.status(500).json({ message: 'Internal server error' });
+  }
+};
+
+export const updateJourneySlots = async (req: Request, res: Response): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ message: 'Unauthorized' });
+    return;
+  }
+
+  const parsed = updateSlotsSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ message: 'Validation failed', errors: parsed.error.flatten() });
+    return;
+  }
+
+  try {
+    const journey = await journeyService.updateSlots(
+      req.params.journeyId,
+      req.user.userId,
+      parsed.data.slots,
+      parsed.data.version,
+    );
+
+    res.status(200).json({ journey: serializeJourney(journey) });
+  } catch (error) {
+    if (error instanceof journeyService.JourneyNotFoundError) {
+      res.status(404).json({ message: error.message });
+      return;
+    }
+    if (error instanceof journeyService.JourneyForbiddenError) {
+      res.status(403).json({ message: error.message });
+      return;
+    }
+    if (error instanceof journeyService.JourneyConflictError) {
+      res.status(409).json({ message: error.message });
+      return;
+    }
+    res.status(500).json({ message: 'Internal server error' });
+  }
+};
+
+export const publishJourney = async (req: Request, res: Response): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ message: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const { journey, snapshot } = await journeyService.publishJourney(
+      req.params.journeyId,
+      req.user.userId,
+    );
+
+    res.status(200).json({
+      journey: serializeJourney(journey!),
+      snapshot: serializeSnapshot(snapshot),
+    });
+  } catch (error) {
+    if (error instanceof journeyService.JourneyNotFoundError) {
+      res.status(404).json({ message: error.message });
+      return;
+    }
+    if (error instanceof journeyService.JourneyForbiddenError) {
+      res.status(403).json({ message: error.message });
+      return;
+    }
+    if (error instanceof journeyService.JourneyConflictError) {
+      res.status(409).json({ message: error.message });
+      return;
+    }
+    if (error instanceof journeyService.JourneyPublishError) {
+      res.status(422).json({ message: error.message });
+      return;
+    }
+    res.status(500).json({ message: 'Internal server error' });
+  }
+};
+
+export const getJourney = async (req: Request, res: Response): Promise<void> => {
+  if (!req.user) {
+    res.status(401).json({ message: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const journey = await journeyService.getJourney(req.params.journeyId, req.user.userId);
+    res.status(200).json({ journey: serializeJourney(journey) });
+  } catch (error) {
+    if (error instanceof journeyService.JourneyNotFoundError) {
+      res.status(404).json({ message: error.message });
+      return;
+    }
+    if (error instanceof journeyService.JourneyForbiddenError) {
+      res.status(403).json({ message: error.message });
+      return;
+    }
+    res.status(500).json({ message: 'Internal server error' });
+  }
+};
+
+export const archiveJourney = async (_req: Request, res: Response): Promise<void> => {
+  res.status(501).json({ message: 'Archive endpoint not yet implemented' });
+};

--- a/apps/api/src/domains/journeys/journey.repository.ts
+++ b/apps/api/src/domains/journeys/journey.repository.ts
@@ -1,0 +1,52 @@
+import mongoose from 'mongoose';
+import VibeJourney, { IVibeJourneyDocument, IJourneySlot, JourneyStatus } from './vibe-journey.model';
+import JourneySnapshot, { IJourneySnapshotDocument } from './journey-snapshot.model';
+
+export const findDraftByAuthor = (authorId: string): Promise<IVibeJourneyDocument | null> =>
+  VibeJourney.findOne({ author: authorId, status: JourneyStatus.DRAFT });
+
+export const findJourneyById = (journeyId: string): Promise<IVibeJourneyDocument | null> =>
+  VibeJourney.findById(journeyId);
+
+export const createDraftJourney = (
+  authorId: string,
+  title: string,
+  description?: string,
+): Promise<IVibeJourneyDocument> =>
+  VibeJourney.create({ author: authorId, title, description });
+
+export const updateJourneySlots = (
+  journeyId: string,
+  slots: IJourneySlot[],
+  currentVersion: number,
+): Promise<IVibeJourneyDocument | null> =>
+  VibeJourney.findOneAndUpdate(
+    { _id: journeyId, status: JourneyStatus.DRAFT, version: currentVersion },
+    { $set: { slots }, $inc: { version: 1 } },
+    { new: true },
+  );
+
+export const findSnapshotByJourneyVersion = (
+  journeyId: string,
+  draftVersion: number,
+): Promise<IJourneySnapshotDocument | null> =>
+  JourneySnapshot.findOne({ journeyId, draftVersion });
+
+export const createSnapshot = (data: {
+  journeyId: mongoose.Types.ObjectId;
+  authorId: mongoose.Types.ObjectId;
+  title: string;
+  description?: string;
+  slots: IJourneySlot[];
+  draftVersion: number;
+}): Promise<IJourneySnapshotDocument> => JourneySnapshot.create(data);
+
+export const publishJourney = (
+  journeyId: string,
+  snapshotId: mongoose.Types.ObjectId,
+): Promise<IVibeJourneyDocument | null> =>
+  VibeJourney.findByIdAndUpdate(
+    journeyId,
+    { $set: { status: JourneyStatus.PUBLISHED, latestPublishedSnapshotId: snapshotId } },
+    { new: true },
+  );

--- a/apps/api/src/domains/journeys/journey.routes.ts
+++ b/apps/api/src/domains/journeys/journey.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { requireAuth } from '../../middleware/auth.middleware';
+import {
+  createDraftJourney,
+  updateJourneySlots,
+  publishJourney,
+  getJourney,
+  archiveJourney,
+} from './journey.controller';
+
+const journeyRouter = Router();
+
+journeyRouter.post('/', requireAuth, createDraftJourney);
+journeyRouter.get('/:journeyId', requireAuth, getJourney);
+journeyRouter.patch('/:journeyId/slots', requireAuth, updateJourneySlots);
+journeyRouter.post('/:journeyId/publish', requireAuth, publishJourney);
+journeyRouter.post('/:journeyId/archive', requireAuth, archiveJourney);
+
+export default journeyRouter;

--- a/apps/api/src/domains/journeys/journey.service.ts
+++ b/apps/api/src/domains/journeys/journey.service.ts
@@ -1,0 +1,129 @@
+import { IJourneySlot, JourneyStatus } from './vibe-journey.model';
+import * as repo from './journey.repository';
+
+export class JourneyConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'JourneyConflictError';
+  }
+}
+
+export class JourneyNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'JourneyNotFoundError';
+  }
+}
+
+export class JourneyForbiddenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'JourneyForbiddenError';
+  }
+}
+
+export class JourneyPublishError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'JourneyPublishError';
+  }
+}
+
+// Single active draft enforced per author — returns existing draft if one exists (idempotent)
+export const createOrReturnDraft = async (
+  authorId: string,
+  title: string,
+  description?: string,
+) => {
+  const existing = await repo.findDraftByAuthor(authorId);
+  if (existing) {
+    return { journey: existing, created: false };
+  }
+  const journey = await repo.createDraftJourney(authorId, title, description);
+  return { journey, created: true };
+};
+
+export const updateSlots = async (
+  journeyId: string,
+  requestingUserId: string,
+  slots: IJourneySlot[],
+  version: number,
+) => {
+  const journey = await repo.findJourneyById(journeyId);
+
+  if (!journey) {
+    throw new JourneyNotFoundError('Journey not found');
+  }
+
+  if (journey.author.toString() !== requestingUserId) {
+    throw new JourneyForbiddenError('Only the journey author can update slots');
+  }
+
+  if (journey.status !== JourneyStatus.DRAFT) {
+    throw new JourneyConflictError('Only draft journeys can be updated');
+  }
+
+  const updated = await repo.updateJourneySlots(journeyId, slots, version);
+
+  if (!updated) {
+    // findOneAndUpdate matched nothing — version conflict
+    throw new JourneyConflictError(
+      'Version conflict: the journey has been modified since you last fetched it',
+    );
+  }
+
+  return updated;
+};
+
+export const publishJourney = async (journeyId: string, requestingUserId: string) => {
+  const journey = await repo.findJourneyById(journeyId);
+
+  if (!journey) {
+    throw new JourneyNotFoundError('Journey not found');
+  }
+
+  if (journey.author.toString() !== requestingUserId) {
+    throw new JourneyForbiddenError('Only the journey author can publish it');
+  }
+
+  if (journey.status !== JourneyStatus.DRAFT) {
+    throw new JourneyConflictError('Only draft journeys can be published');
+  }
+
+  if (journey.slots.length === 0) {
+    throw new JourneyPublishError('Cannot publish a journey with no slots');
+  }
+
+  // Prevent duplicate snapshots for the same draft version
+  const existingSnapshot = await repo.findSnapshotByJourneyVersion(journeyId, journey.version);
+  if (existingSnapshot) {
+    const published = await repo.publishJourney(journeyId, existingSnapshot._id as any);
+    return { journey: published, snapshot: existingSnapshot, alreadyExists: true };
+  }
+
+  const snapshot = await repo.createSnapshot({
+    journeyId: journey._id as any,
+    authorId: journey.author as any,
+    title: journey.title,
+    description: journey.description,
+    slots: journey.slots,
+    draftVersion: journey.version,
+  });
+
+  const published = await repo.publishJourney(journeyId, snapshot._id as any);
+  return { journey: published, snapshot, alreadyExists: false };
+};
+
+export const getJourney = async (journeyId: string, requestingUserId: string) => {
+  const journey = await repo.findJourneyById(journeyId);
+
+  if (!journey) {
+    throw new JourneyNotFoundError('Journey not found');
+  }
+
+  if (journey.author.toString() !== requestingUserId && journey.status !== JourneyStatus.PUBLISHED) {
+    throw new JourneyForbiddenError('Access denied');
+  }
+
+  return journey;
+};

--- a/apps/api/src/domains/journeys/journey.validation.ts
+++ b/apps/api/src/domains/journeys/journey.validation.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+export const journeySlotSchema = z.object({
+  order: z.number().int().min(0, 'Slot order must be non-negative'),
+  trackRef: z.string().min(1, 'Track reference is required').trim(),
+  platform: z.string().min(1, 'Platform is required').trim().toLowerCase(),
+  notes: z.string().max(1000, 'Notes cannot exceed 1000 characters').trim().optional(),
+});
+
+export const createDraftJourneySchema = z.object({
+  title: z.string().min(1, 'Title is required').max(200, 'Title cannot exceed 200 characters').trim(),
+  description: z.string().max(2000, 'Description cannot exceed 2000 characters').trim().optional(),
+});
+
+export const updateSlotsSchema = z.object({
+  slots: z
+    .array(journeySlotSchema)
+    .min(1, 'At least one slot is required')
+    .refine(
+      (slots) => {
+        const orders = slots.map((s) => s.order);
+        return new Set(orders).size === orders.length;
+      },
+      { message: 'Slot order values must be unique' },
+    )
+    .refine(
+      (slots) => {
+        const sorted = [...slots].map((s) => s.order).sort((a, b) => a - b);
+        return sorted.every((val, i) => val === i);
+      },
+      { message: 'Slot orders must form a contiguous sequence starting at 0' },
+    ),
+  version: z.number().int().min(1, 'Version must be a positive integer'),
+});
+
+export type CreateDraftJourneyDto = z.infer<typeof createDraftJourneySchema>;
+export type UpdateSlotsDto = z.infer<typeof updateSlotsSchema>;

--- a/apps/api/src/domains/journeys/vibe-journey.model.ts
+++ b/apps/api/src/domains/journeys/vibe-journey.model.ts
@@ -1,0 +1,102 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export enum JourneyStatus {
+  DRAFT = 'DRAFT',
+  PUBLISHED = 'PUBLISHED',
+  ARCHIVED = 'ARCHIVED',
+}
+
+export interface IJourneySlot {
+  order: number;
+  trackRef: string;
+  platform: string;
+  notes?: string;
+}
+
+export interface IVibeJourneyDocument extends Document {
+  author: mongoose.Types.ObjectId;
+  title: string;
+  description?: string;
+  status: JourneyStatus;
+  slots: IJourneySlot[];
+  version: number;
+  latestPublishedSnapshotId?: mongoose.Types.ObjectId;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const JourneySlotSchema = new Schema<IJourneySlot>(
+  {
+    order: {
+      type: Number,
+      required: true,
+      min: [0, 'Slot order must be non-negative'],
+    },
+    trackRef: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    platform: {
+      type: String,
+      required: true,
+      trim: true,
+      lowercase: true,
+    },
+    notes: {
+      type: String,
+      trim: true,
+      maxlength: [1000, 'Slot notes cannot exceed 1000 characters'],
+    },
+  },
+  { _id: false },
+);
+
+const VibeJourneySchema = new Schema<IVibeJourneyDocument>(
+  {
+    author: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+      immutable: true,
+    },
+    title: {
+      type: String,
+      required: [true, 'Journey title is required'],
+      trim: true,
+      maxlength: [200, 'Title cannot exceed 200 characters'],
+    },
+    description: {
+      type: String,
+      trim: true,
+      maxlength: [2000, 'Description cannot exceed 2000 characters'],
+    },
+    status: {
+      type: String,
+      enum: Object.values(JourneyStatus),
+      default: JourneyStatus.DRAFT,
+      index: true,
+    },
+    slots: {
+      type: [JourneySlotSchema],
+      default: [],
+    },
+    version: {
+      type: Number,
+      default: 1,
+      min: 1,
+    },
+    latestPublishedSnapshotId: {
+      type: Schema.Types.ObjectId,
+      ref: 'JourneySnapshot',
+    },
+  },
+  { timestamps: true },
+);
+
+VibeJourneySchema.index({ author: 1, status: 1, createdAt: -1 });
+
+const VibeJourney = mongoose.model<IVibeJourneyDocument>('VibeJourney', VibeJourneySchema);
+
+export default VibeJourney;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import connectDB from './config/db';
 import { apiEnv } from './config/env';
 import { identityRouter } from './domains/identity';
-import { journeysRouter } from './domains/journeys';
+import { journeysRouter, journeyRouter } from './domains/journeys';
 import { discoveryRouter } from './domains/discovery';
 import { paymentsRouter } from './domains/payments';
 import { notFoundHandler } from './middleware/not-found.middleware';
@@ -18,6 +18,7 @@ app.use(express.json());
 app.use(contextMiddleware);
 app.use('/auth', identityRouter);
 app.use('/bookings', journeysRouter);
+app.use('/journeys', journeyRouter);
 app.use('/discover', discoveryRouter);
 app.use('/payments', paymentsRouter);
 


### PR DESCRIPTION
## Summary


Implements the full Vibe Journey authoring API for the journeys domain across four linked issues.

### Issue #191 — API module bootstrap
- `journey.routes.ts` — registers all journey endpoints under `/journeys`
- `journey.controller.ts` — controller handlers for all endpoints
- `journey.service.ts` — service layer with domain business rules and typed error classes
- `journey.repository.ts` — database access layer (Mongoose)
- `journey.validation.ts` — Zod schemas for request bodies
- `index.ts` & `src/index.ts` — wires `journeyRouter` into the Express app at `/journeys`

### Issue #192 — Draft journey creation (`POST /journeys`)
- Single active draft enforced per author — if a draft already exists it is returned (idempotent, HTTP 200); new drafts return HTTP 201
- Validates `title` (required, ≤ 200 chars) and optional `description` (≤ 2000 chars)
- Requires authentication

### Issue #193 — Slot update (`PATCH /journeys/:journeyId/slots`)
- Accepts an array of slots with `order`, `trackRef`, `platform`, and optional `notes`
- Validates that slot orders are unique and form a contiguous sequence starting at 0
- Optimistic concurrency via `version` field — mismatched version returns `409 Conflict`
- Rejects updates to non-draft journeys (`409`)
- Only the journey author may update slots (`403`)

### Issue #194 — Publish with snapshot creation (`POST /journeys/:journeyId/publish`)
- Validates publish readiness: journey must be DRAFT and have at least one slot
- Creates an immutable `JourneySnapshot` document (deep copy of slots + metadata)
- A unique index on `(journeyId, draftVersion)` prevents duplicate snapshots for the same draft version
- Updates the journey's `status → PUBLISHED` and sets `latestPublishedSnapshotId`
- Only the journey author may publish (`403`)

### New files
| File | Purpose |
|---|---|
| `vibe-journey.model.ts` | Mongoose model for draft/published journeys with slots |
| `journey-snapshot.model.ts` | Immutable snapshot model created on publish |
| `journey.validation.ts` | Zod schemas for create-draft and update-slots |
| `journey.repository.ts` | Repository functions (DB access) |
| `journey.service.ts` | Business logic + typed domain errors |
| `journey.controller.ts` | Express request handlers |
| `journey.routes.ts` | Route registration with `requireAuth` middleware |

## Test plan

- [ ] `POST /journeys` with valid body → 201 with new draft journey
- [ ] `POST /journeys` again with same user → 200 returns existing draft (idempotent)
- [ ] `PATCH /journeys/:id/slots` with valid slots and correct version → 200
- [ ] `PATCH /journeys/:id/slots` with wrong version → 409 Conflict
- [ ] `PATCH /journeys/:id/slots` with non-contiguous orders → 400 Validation failed
- [ ] `POST /journeys/:id/publish` on journey with slots → 200 with snapshot
- [ ] `POST /journeys/:id/publish` again → 200, no duplicate snapshot created
- [ ] `POST /journeys/:id/publish` on journey with no slots → 422 Unprocessable
- [ ] All endpoints with no auth token → 401

Closes #191, Closes #192, Closes #193, Closes #194
