### PR TITLE
feat: resolve thommyy7 issues #203, #204, #205, #206

### DIFF
--- a/apps/web/app/dashboard/journey/new/page.tsx
+++ b/apps/web/app/dashboard/journey/new/page.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useReducer, useCallback } from 'react';
+import {
+  JourneyEditorMachine,
+  EditorState,
+  SLOT_COUNT,
+  type SlotDraft,
+} from '@/lib/journey-editor';
+
+const machine = new JourneyEditorMachine();
+machine.load({ title: '', slots: machine.getSnapshot().draft.slots });
+
+function useEditorMachine() {
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  const snap = machine.getSnapshot();
+
+  const editSlot = useCallback(
+    (index: number, patch: Partial<Pick<SlotDraft, 'trackId' | 'authoredNote'>>) => {
+      machine.editSlot(index, patch);
+      forceUpdate();
+    },
+    [],
+  );
+
+  const setTitle = useCallback((title: string) => {
+    machine.setTitle(title);
+    forceUpdate();
+  }, []);
+
+  const publish = useCallback(() => {
+    machine.publish();
+    forceUpdate();
+  }, []);
+
+  return { snap, editSlot, setTitle, publish };
+}
+
+const SLOT_LABELS = [
+  'Opening Vibe',
+  'Build-Up',
+  'First Peak',
+  'Mid-Journey',
+  'Second Peak',
+  'Wind-Down',
+  'Closing Note',
+] as const;
+
+function SlotCard({
+  slot,
+  label,
+  onChange,
+}: {
+  slot: SlotDraft;
+  label: string;
+  onChange: (patch: Partial<Pick<SlotDraft, 'trackId' | 'authoredNote'>>) => void;
+}) {
+  const hasErrors = slot.errors.length > 0;
+
+  return (
+    <article
+      className={`rounded-2xl border p-5 ${hasErrors ? 'border-red-300 bg-red-50' : 'border-zinc-200 bg-white'} shadow-sm`}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-zinc-900 text-xs font-bold text-white">
+          {slot.index + 1}
+        </span>
+        <h3 className="text-sm font-semibold text-zinc-900">{label}</h3>
+      </div>
+
+      {/* Provider-track selection placeholder */}
+      <input
+        type="text"
+        placeholder="Track ID or search…"
+        value={slot.trackId ?? ''}
+        onChange={(e) => onChange({ trackId: e.target.value })}
+        aria-label={`Track for slot ${slot.index + 1}: ${label}`}
+        className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+      />
+
+      {/* Authored note */}
+      <textarea
+        placeholder="Add a note for this slot (optional)"
+        value={slot.authoredNote ?? ''}
+        onChange={(e) => onChange({ authoredNote: e.target.value })}
+        aria-label={`Note for slot ${slot.index + 1}`}
+        rows={2}
+        className="mt-2 w-full resize-none rounded-md border border-zinc-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+      />
+
+      {/* Validation messages */}
+      {hasErrors && (
+        <ul className="mt-2 space-y-0.5" role="alert">
+          {slot.errors.map((err) => (
+            <li key={err} className="text-xs text-red-600">
+              {err}
+            </li>
+          ))}
+        </ul>
+      )}
+    </article>
+  );
+}
+
+const PUBLISH_LABEL: Partial<Record<EditorState, string>> = {
+  [EditorState.PUBLISH_READY]: 'Publish Journey',
+  [EditorState.PUBLISHED]: 'Published ✓',
+  [EditorState.SAVING]: 'Saving…',
+  [EditorState.SAVE_ERROR]: 'Retry Save',
+  [EditorState.CONFLICT]: 'Conflict — reload',
+};
+
+export default function VibeJourneyEditorPage() {
+  const { snap, editSlot, setTitle, publish } = useEditorMachine();
+  const { draft, state, isDirty, saveError, conflictMessage } = snap;
+
+  const isPublishable = state === EditorState.PUBLISH_READY;
+  const isPublished = state === EditorState.PUBLISHED;
+  const filledSlots = draft.slots.filter((s) => s.trackId?.trim()).length;
+
+  return (
+    <main className="min-h-screen bg-zinc-50 px-6 py-16">
+      <section className="mx-auto max-w-3xl space-y-6">
+
+        {/* Header */}
+        <header className="rounded-2xl border border-zinc-200 bg-white p-8 shadow-sm">
+          <h1 className="text-3xl font-semibold text-zinc-900">Vibe Journey Editor</h1>
+          <p className="mt-1 text-sm text-zinc-500">
+            Fill all {SLOT_COUNT} slots to unlock publishing.
+          </p>
+
+          <input
+            type="text"
+            placeholder="Journey title…"
+            value={draft.title}
+            onChange={(e) => setTitle(e.target.value)}
+            aria-label="Journey title"
+            className="mt-4 w-full rounded-md border border-zinc-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-zinc-900"
+          />
+        </header>
+
+        {/* Publication status banner */}
+        {saveError && (
+          <div role="alert" className="rounded-xl border border-red-200 bg-red-50 px-5 py-3 text-sm text-red-700">
+            Save failed: {saveError}
+          </div>
+        )}
+        {conflictMessage && (
+          <div role="alert" className="rounded-xl border border-amber-200 bg-amber-50 px-5 py-3 text-sm text-amber-700">
+            Conflict: {conflictMessage}
+          </div>
+        )}
+        {isPublished && (
+          <div role="status" className="rounded-xl border border-emerald-200 bg-emerald-50 px-5 py-3 text-sm text-emerald-700">
+            Journey published successfully.
+          </div>
+        )}
+
+        {/* Progress indicator */}
+        <div className="flex items-center justify-between text-xs text-zinc-500">
+          <span>{filledSlots} / {SLOT_COUNT} slots filled</span>
+          {isDirty && <span className="text-amber-600">Unsaved changes</span>}
+        </div>
+
+        {/* 7 slot cards */}
+        <div className="space-y-4">
+          {draft.slots.map((slot, i) => (
+            <SlotCard
+              key={slot.index}
+              slot={slot}
+              label={SLOT_LABELS[i]}
+              onChange={(patch) => editSlot(i, patch)}
+            />
+          ))}
+        </div>
+
+        {/* Publish CTA */}
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={publish}
+            disabled={!isPublishable}
+            aria-disabled={!isPublishable}
+            className={`rounded-xl px-6 py-3 text-sm font-semibold transition ${
+              isPublishable
+                ? 'bg-zinc-900 text-white hover:bg-zinc-700'
+                : 'cursor-not-allowed bg-zinc-200 text-zinc-400'
+            }`}
+          >
+            {PUBLISH_LABEL[state] ?? 'Publish Journey'}
+          </button>
+        </div>
+
+      </section>
+    </main>
+  );
+}

--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -13,6 +13,7 @@ const navByRole: Record<UserRole, Array<{ href: string; label: string }>> = {
   [UserRole.DJ]: [
     { href: '/dashboard', label: 'Overview' },
     { href: '/dashboard/profile', label: 'Profile' },
+    { href: '/dashboard/journey/new', label: 'New Journey' },
     { href: '/dashboard/bookings', label: 'Bookings' },
   ],
   [UserRole.PLANNER]: [

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { AuthBootstrap } from "@/components/auth-bootstrap";
 import { AuthSessionSync } from "@/components/auth-session-sync";
+import { SessionBootstrap } from "@/components/session-bootstrap";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -18,6 +19,7 @@ export default function RootLayout({
       <body className="antialiased">
         <AuthBootstrap />
         <AuthSessionSync />
+        <SessionBootstrap />
         {children}
       </body>
     </html>

--- a/apps/web/components/session-bootstrap.tsx
+++ b/apps/web/components/session-bootstrap.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { AccountStatus, ModerationState } from '@mixmatch/types';
+import { useAuthStore } from '@/store/auth.store';
+import { useSessionStore } from '@/store/session.store';
+import { apiRequest } from '@/lib/api/client';
+
+interface MeResponse {
+  user: {
+    id: string;
+    role: string;
+    accountStatus?: AccountStatus;
+    moderationState?: ModerationState;
+    onboardingCompleted: boolean;
+    privacySettings?: { blindListeningEligible?: boolean };
+  };
+}
+
+interface UnreadResponse {
+  unreadResonances: number;
+}
+
+/**
+ * SessionBootstrap (#203)
+ * Hydrates the typed actor context store once per session.
+ * Protected routes can read from useSessionStore without duplicate fetches.
+ */
+export function SessionBootstrap() {
+  const token = useAuthStore((s) => s.token);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const logout = useAuthStore((s) => s.logout);
+  const { status, setLoading, setReady, setError } = useSessionStore();
+  const bootstrapped = useRef(false);
+
+  useEffect(() => {
+    if (!isAuthenticated || !token || bootstrapped.current || status === 'ready') return;
+    bootstrapped.current = true;
+    setLoading();
+
+    Promise.all([
+      apiRequest<MeResponse>('/auth/me', { token }),
+      apiRequest<UnreadResponse>('/resonance/unread', { token }).catch(() => ({ unreadResonances: 0 })),
+    ])
+      .then(([meRes, unreadRes]) => {
+        const u = meRes.user;
+        setReady({
+          userId: u.id,
+          role: u.role as import('@mixmatch/types').UserRole,
+          accountStatus: u.accountStatus ?? AccountStatus.ACTIVE,
+          moderationState: u.moderationState ?? ModerationState.CLEAR,
+          profileComplete: u.onboardingCompleted,
+          blindModeEligible: u.privacySettings?.blindListeningEligible ?? false,
+          unreadResonances: unreadRes.unreadResonances,
+        });
+      })
+      .catch(() => {
+        setError('Session could not be loaded. Please log in again.');
+        logout();
+      });
+  }, [isAuthenticated, token, status, setLoading, setReady, setError, logout]);
+
+  return null;
+}

--- a/apps/web/lib/api/discovery-feed.ts
+++ b/apps/web/lib/api/discovery-feed.ts
@@ -1,0 +1,159 @@
+/**
+ * Discovery Feed Query Layer (#206)
+ *
+ * Typed, reusable data-access layer for discovery surfaces.
+ * Handles cursor pagination, filter persistence, cursor reset on filter change,
+ * and normalises blind vs standard payload shapes for the UI layer.
+ */
+
+import { RevealPhase } from '@mixmatch/types';
+import { apiRequest } from './client';
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export interface DiscoveryFilters {
+  q?: string;
+  genre?: string;
+  availabilityStatus?: string;
+}
+
+export interface RawDiscoveryItem {
+  id: string;
+  stageName: string;
+  bio?: string;
+  genres: string[];
+  vibeTags: string[];
+  pricing?: { min: number; max: number };
+  availabilityStatus: string;
+  location?: string;
+  createdAt?: string;
+}
+
+export interface NormalizedDiscoveryItem extends RawDiscoveryItem {
+  revealPhase: RevealPhase;
+}
+
+export interface DiscoveryPage {
+  items: NormalizedDiscoveryItem[];
+  nextCursor: string | null;
+  hasNextPage: boolean;
+}
+
+interface RawPage {
+  items: RawDiscoveryItem[];
+  nextCursor?: string;
+  hasNextPage?: boolean;
+}
+
+// ── Normalizer ────────────────────────────────────────────────────────────
+
+/**
+ * Blind mode: strip identity fields and force BLIND phase.
+ * Standard mode: pass through with FULL phase (server already redacts per reveal state).
+ */
+function normalize(item: RawDiscoveryItem, blind: boolean): NormalizedDiscoveryItem {
+  if (blind) {
+    return {
+      id: item.id,
+      stageName: 'Anonymous DJ',
+      genres: item.genres,
+      vibeTags: item.vibeTags,
+      availabilityStatus: item.availabilityStatus,
+      revealPhase: RevealPhase.BLIND,
+    };
+  }
+  return { ...item, revealPhase: RevealPhase.FULL };
+}
+
+// ── Query builder ─────────────────────────────────────────────────────────
+
+function buildPath(filters: DiscoveryFilters, cursor?: string, limit = 20): string {
+  const params = new URLSearchParams();
+  if (filters.q?.trim()) params.set('q', filters.q.trim());
+  if (filters.genre?.trim()) params.set('genre', filters.genre.trim());
+  if (filters.availabilityStatus?.trim()) params.set('availabilityStatus', filters.availabilityStatus.trim());
+  if (cursor) params.set('cursor', cursor);
+  params.set('limit', String(limit));
+  const qs = params.toString();
+  return `/discover/djs${qs ? `?${qs}` : ''}`;
+}
+
+// ── Fetcher ───────────────────────────────────────────────────────────────
+
+export async function fetchDiscoveryPage(
+  filters: DiscoveryFilters,
+  options: { token: string; cursor?: string; blind?: boolean; limit?: number },
+): Promise<DiscoveryPage> {
+  const { token, cursor, blind = false, limit } = options;
+  const path = buildPath(filters, cursor, limit);
+  const raw = await apiRequest<RawPage>(path, { token });
+
+  return {
+    items: raw.items.map((item) => normalize(item, blind)),
+    nextCursor: raw.nextCursor ?? null,
+    hasNextPage: raw.hasNextPage ?? false,
+  };
+}
+
+// ── Stateful feed accumulator ─────────────────────────────────────────────
+
+export interface FeedState {
+  items: NormalizedDiscoveryItem[];
+  cursor: string | null;
+  hasNextPage: boolean;
+  filters: DiscoveryFilters;
+  loading: boolean;
+  error: string | null;
+}
+
+export type FeedAction =
+  | { type: 'FETCH_START' }
+  | { type: 'FETCH_SUCCESS'; page: DiscoveryPage; append: boolean }
+  | { type: 'FETCH_ERROR'; message: string }
+  | { type: 'SET_FILTERS'; filters: DiscoveryFilters };
+
+export function feedReducer(state: FeedState, action: FeedAction): FeedState {
+  switch (action.type) {
+    case 'FETCH_START':
+      return { ...state, loading: true, error: null };
+
+    case 'FETCH_SUCCESS':
+      return {
+        ...state,
+        loading: false,
+        items: action.append
+          ? dedupeById([...state.items, ...action.page.items])
+          : action.page.items,
+        cursor: action.page.nextCursor,
+        hasNextPage: action.page.hasNextPage,
+      };
+
+    case 'FETCH_ERROR':
+      return { ...state, loading: false, error: action.message };
+
+    case 'SET_FILTERS':
+      // Reset cursor when filters change to prevent duplicate cards
+      return { ...state, filters: action.filters, cursor: null, items: [] };
+
+    default:
+      return state;
+  }
+}
+
+export const initialFeedState = (filters: DiscoveryFilters = {}): FeedState => ({
+  items: [],
+  cursor: null,
+  hasNextPage: false,
+  filters,
+  loading: false,
+  error: null,
+});
+
+function dedupeById(items: NormalizedDiscoveryItem[]): NormalizedDiscoveryItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+}

--- a/apps/web/lib/journey-editor.ts
+++ b/apps/web/lib/journey-editor.ts
@@ -1,0 +1,180 @@
+/**
+ * Journey Editor State Machine (#204)
+ *
+ * Manages draft load, dirty tracking, slot edits, validation,
+ * optimistic save, conflict handling, and publish readiness.
+ * UI rendering stays thin — all behavior lives here.
+ */
+
+export const SLOT_COUNT = 7;
+
+export enum EditorState {
+  IDLE = 'IDLE',
+  LOADING = 'LOADING',
+  EDITING = 'EDITING',
+  SAVING = 'SAVING',
+  SAVE_ERROR = 'SAVE_ERROR',
+  CONFLICT = 'CONFLICT',
+  PUBLISH_READY = 'PUBLISH_READY',
+  PUBLISHED = 'PUBLISHED',
+}
+
+export interface SlotDraft {
+  index: number; // 0-6
+  trackId?: string;
+  authoredNote?: string;
+  errors: string[];
+}
+
+export interface JourneyDraft {
+  id?: string;
+  title: string;
+  slots: SlotDraft[];
+  serverVersion?: number;
+}
+
+export interface EditorSnapshot {
+  state: EditorState;
+  draft: JourneyDraft;
+  isDirty: boolean;
+  saveError: string | null;
+  conflictMessage: string | null;
+}
+
+const emptySlots = (): SlotDraft[] =>
+  Array.from({ length: SLOT_COUNT }, (_, i) => ({ index: i, errors: [] }));
+
+const validateSlot = (slot: SlotDraft): string[] => {
+  const errors: string[] = [];
+  if (!slot.trackId?.trim()) errors.push('Track is required');
+  return errors;
+};
+
+const isPublishReady = (slots: SlotDraft[]): boolean =>
+  slots.every((s) => s.trackId?.trim());
+
+export class JourneyEditorMachine {
+  private snap: EditorSnapshot;
+
+  constructor(initial?: Partial<JourneyDraft>) {
+    this.snap = {
+      state: EditorState.IDLE,
+      draft: {
+        title: '',
+        slots: emptySlots(),
+        ...initial,
+      },
+      isDirty: false,
+      saveError: null,
+      conflictMessage: null,
+    };
+  }
+
+  // ── Queries ──────────────────────────────────────────────────────────────
+
+  getSnapshot(): Readonly<EditorSnapshot> {
+    return this.snap;
+  }
+
+  // ── Commands ─────────────────────────────────────────────────────────────
+
+  load(draft: JourneyDraft): void {
+    this.snap = {
+      state: EditorState.EDITING,
+      draft: { ...draft, slots: draft.slots.map((s) => ({ ...s, errors: [] })) },
+      isDirty: false,
+      saveError: null,
+      conflictMessage: null,
+    };
+  }
+
+  setTitle(title: string): void {
+    if (!this.isEditable()) return;
+    this.snap.draft.title = title;
+    this.snap.isDirty = true;
+    this.snap.state = EditorState.EDITING;
+  }
+
+  editSlot(index: number, patch: Partial<Pick<SlotDraft, 'trackId' | 'authoredNote'>>): void {
+    if (!this.isEditable()) return;
+    this.assertValidIndex(index);
+
+    const slot = this.snap.draft.slots[index];
+    Object.assign(slot, patch);
+    slot.errors = validateSlot(slot);
+
+    this.snap.isDirty = true;
+    this.snap.state = isPublishReady(this.snap.draft.slots)
+      ? EditorState.PUBLISH_READY
+      : EditorState.EDITING;
+  }
+
+  /** Slots are ordered 0-6 and cannot be reordered arbitrarily — only adjacent swaps. */
+  swapSlots(fromIndex: number, toIndex: number): void {
+    if (!this.isEditable()) return;
+    this.assertValidIndex(fromIndex);
+    this.assertValidIndex(toIndex);
+
+    if (Math.abs(fromIndex - toIndex) !== 1) {
+      throw new Error('Slots can only be swapped with adjacent neighbours');
+    }
+
+    const slots = this.snap.draft.slots;
+    [slots[fromIndex], slots[toIndex]] = [slots[toIndex], slots[fromIndex]];
+    slots[fromIndex].index = fromIndex;
+    slots[toIndex].index = toIndex;
+
+    this.snap.isDirty = true;
+  }
+
+  startSave(): void {
+    if (this.snap.state === EditorState.SAVING) return;
+    this.snap.state = EditorState.SAVING;
+    this.snap.saveError = null;
+  }
+
+  saveSuccess(serverVersion: number): void {
+    this.snap.draft.serverVersion = serverVersion;
+    this.snap.isDirty = false;
+    this.snap.saveError = null;
+    this.snap.state = isPublishReady(this.snap.draft.slots)
+      ? EditorState.PUBLISH_READY
+      : EditorState.EDITING;
+  }
+
+  saveFailure(message: string): void {
+    this.snap.state = EditorState.SAVE_ERROR;
+    this.snap.saveError = message;
+  }
+
+  conflict(message: string): void {
+    this.snap.state = EditorState.CONFLICT;
+    this.snap.conflictMessage = message;
+  }
+
+  resolveConflict(serverDraft: JourneyDraft): void {
+    this.load(serverDraft);
+  }
+
+  publish(): void {
+    if (this.snap.state !== EditorState.PUBLISH_READY) return;
+    this.snap.state = EditorState.PUBLISHED;
+    this.snap.isDirty = false;
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  private isEditable(): boolean {
+    return [
+      EditorState.EDITING,
+      EditorState.SAVE_ERROR,
+      EditorState.PUBLISH_READY,
+    ].includes(this.snap.state);
+  }
+
+  private assertValidIndex(index: number): void {
+    if (index < 0 || index >= SLOT_COUNT) {
+      throw new RangeError(`Slot index ${index} is out of range (0-${SLOT_COUNT - 1})`);
+    }
+  }
+}

--- a/apps/web/store/session.store.ts
+++ b/apps/web/store/session.store.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { create } from 'zustand';
+import { AccountStatus, ModerationState, UserRole } from '@mixmatch/types';
+
+export type BootstrapStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+export interface ActorContext {
+  userId: string;
+  role: UserRole;
+  accountStatus: AccountStatus;
+  moderationState: ModerationState;
+  profileComplete: boolean;
+  blindModeEligible: boolean;
+  unreadResonances: number;
+}
+
+interface SessionStore {
+  status: BootstrapStatus;
+  actor: ActorContext | null;
+  error: string | null;
+  setLoading: () => void;
+  setReady: (actor: ActorContext) => void;
+  setError: (message: string) => void;
+  reset: () => void;
+}
+
+export const useSessionStore = create<SessionStore>((set) => ({
+  status: 'idle',
+  actor: null,
+  error: null,
+  setLoading: () => set({ status: 'loading', error: null }),
+  setReady: (actor) => set({ status: 'ready', actor, error: null }),
+  setError: (error) => set({ status: 'error', error, actor: null }),
+  reset: () => set({ status: 'idle', actor: null, error: null }),
+}));


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to thommyy7 in Sprint 1 – Platform Foundation and Domain Reset.

---

### #203 · Build web session bootstrap layer using typed actor context

- New store: `apps/web/store/session.store.ts`
  - `ActorContext` type: `userId`, `role`, `accountStatus`, `moderationState`, `profileComplete`, `blindModeEligible`, `unreadResonances`
  - `useSessionStore` (Zustand) with `idle | loading | ready | error` status
- New component: `apps/web/components/session-bootstrap.tsx`
  - Fetches `/auth/me` + `/resonance/unread` in parallel on first authenticated render
  - Hydrates the actor context store; redirects to logout on failure
  - Protected routes can read actor context without duplicate requests
- Wired into root `apps/web/app/layout.tsx` alongside `AuthBootstrap`

---

### #204 · Implement journey editor state machine for web draft authoring

- New module: `apps/web/lib/journey-editor.ts`
- `JourneyEditorMachine` class with states: `IDLE`, `LOADING`, `EDITING`, `SAVING`, `SAVE_ERROR`, `CONFLICT`, `PUBLISH_READY`, `PUBLISHED`
- Handles: dirty tracking, per-slot validation, adjacent-only slot swaps (invalid reorders throw), optimistic save/failure, conflict detection + resolution, publish-readiness gating
- UI rendering stays thin — all behaviour isolated in the machine

---

### #205 · Build web Vibe Journey editor shell with slot-specific form sections

- New route: `apps/web/app/dashboard/journey/new/page.tsx`
- 7 labelled `SlotCard` sections: Opening Vibe → Build-Up → First Peak → Mid-Journey → Second Peak → Wind-Down → Closing Note
- Per-slot track ID input (provider-track selection placeholder) + authored note textarea
- Per-slot validation messaging rendered inline
- Unsaved-change indicator, save-error and conflict banners, publication status banner
- Publish CTA disabled until all 7 slots are filled; label reflects machine state
- Integrated with `JourneyEditorMachine` from #204
- Added **New Journey** nav link for `DJ` role in dashboard layout

---

### #206 · Create web discovery feed query layer with cursor pagination

- New module: `apps/web/lib/api/discovery-feed.ts`
- `fetchDiscoveryPage(filters, { token, cursor, blind, limit })` — typed fetcher
- Blind/standard normalizer: blind mode strips identity fields and forces `RevealPhase.BLIND`; standard mode passes through server-redacted payload
- `feedReducer` + `initialFeedState` for stateful accumulation in any component
- Cursor resets automatically on filter change (`SET_FILTERS` action) to prevent duplicate cards
- `dedupeById` guard on append to handle race conditions

---

Closes #203, Closes #204, Closes #205, Closes #206