### PR TITLE
feat(tracks): provider payload cache, upsert service, resolution endpoint, preview capability (#223 #224 #225 #226)

### DIFF
--- a/apps/api/src/domains/tracks/index.ts
+++ b/apps/api/src/domains/tracks/index.ts
@@ -1,0 +1,11 @@
+export { default as tracksRouter } from './tracks.routes';
+export { TrackReferenceUpsertService } from './track-reference-upsert.service';
+export { PreviewCapabilityService, PreviewStrategy } from './preview-capability.service';
+export {
+  MongoProviderPayloadCache,
+  buildCacheKey,
+  DEFAULT_TTL_SECONDS,
+} from './provider-payload-cache';
+export type { IProviderPayloadCache } from './provider-payload-cache';
+export type { AudioPreviewCapability, PlatformContext } from './preview-capability.service';
+export type { TrackReferenceUpsertInput } from './track-reference-upsert.service';

--- a/apps/api/src/domains/tracks/preview-capability.service.ts
+++ b/apps/api/src/domains/tracks/preview-capability.service.ts
@@ -1,0 +1,93 @@
+import { ProviderType } from '@mixmatch/types';
+
+// ── Preview strategy enum ──────────────────────────────────────────────────────
+
+export enum PreviewStrategy {
+  /** Track has a direct preview URL – auto-play is safe */
+  AUTO_PLAY = 'AUTO_PLAY',
+  /** No direct URL; client must hand off to the provider's player */
+  PROVIDER_HANDOFF = 'PROVIDER_HANDOFF',
+  /** Preview is unavailable in this context; show a silent placeholder */
+  SILENT_PLACEHOLDER = 'SILENT_PLACEHOLDER',
+}
+
+// ── Capability model ───────────────────────────────────────────────────────────
+
+export interface AudioPreviewCapability {
+  provider: ProviderType;
+  providerTrackId: string;
+  hasPreviewUrl: boolean;
+  /** Whether the provider restricts streaming in the given market */
+  streamingRestricted: boolean;
+  /** ISO 3166-1 alpha-2 market code, e.g. "US" */
+  market?: string;
+  strategy: PreviewStrategy;
+}
+
+// ── Platform context ───────────────────────────────────────────────────────────
+
+export interface PlatformContext {
+  /** "web" or "mobile" */
+  platform: 'web' | 'mobile';
+  /** ISO 3166-1 alpha-2 market code */
+  market?: string;
+}
+
+// ── Fallback decision service ──────────────────────────────────────────────────
+
+export interface IPreviewCapabilityService {
+  resolve(
+    provider: ProviderType,
+    providerTrackId: string,
+    previewUrl: string | undefined,
+    context: PlatformContext,
+  ): AudioPreviewCapability;
+}
+
+export class PreviewCapabilityService implements IPreviewCapabilityService {
+  /**
+   * Deterministically decide the preview strategy from track metadata and
+   * platform context.  No I/O – pure function wrapped in a class for DI.
+   */
+  resolve(
+    provider: ProviderType,
+    providerTrackId: string,
+    previewUrl: string | undefined,
+    context: PlatformContext,
+  ): AudioPreviewCapability {
+    const hasPreviewUrl = Boolean(previewUrl);
+    const streamingRestricted = this.isStreamingRestricted(provider, context);
+
+    let strategy: PreviewStrategy;
+
+    if (hasPreviewUrl && !streamingRestricted) {
+      strategy = PreviewStrategy.AUTO_PLAY;
+    } else if (!hasPreviewUrl && !streamingRestricted) {
+      // Provider may still support in-app playback via handoff
+      strategy = PreviewStrategy.PROVIDER_HANDOFF;
+    } else {
+      strategy = PreviewStrategy.SILENT_PLACEHOLDER;
+    }
+
+    return {
+      provider,
+      providerTrackId,
+      hasPreviewUrl,
+      streamingRestricted,
+      market: context.market,
+      strategy,
+    };
+  }
+
+  /**
+   * Streaming restriction rules.
+   * Extend this as provider/geo policies become known.
+   */
+  private isStreamingRestricted(provider: ProviderType, context: PlatformContext): boolean {
+    // Apple Music previews are only available on mobile via their SDK
+    if (provider === ProviderType.APPLE_MUSIC && context.platform === 'web') {
+      return true;
+    }
+    return false;
+  }
+}

--- a/apps/api/src/domains/tracks/provider-payload-cache.ts
+++ b/apps/api/src/domains/tracks/provider-payload-cache.ts
@@ -1,0 +1,74 @@
+import mongoose, { Document, Schema } from 'mongoose';
+import { ProviderType } from '@mixmatch/types';
+
+// ── Cache key helpers ──────────────────────────────────────────────────────────
+
+export const buildCacheKey = (provider: ProviderType, providerTrackId: string): string =>
+  `${provider}:${providerTrackId}`;
+
+// ── Swappable cache interface ──────────────────────────────────────────────────
+
+export interface IProviderPayloadCache {
+  get(key: string): Promise<Record<string, unknown> | null>;
+  set(key: string, payload: Record<string, unknown>, ttlSeconds?: number): Promise<void>;
+  invalidate(key: string): Promise<void>;
+  invalidateByProvider(provider: ProviderType): Promise<void>;
+}
+
+// ── Mongo document ─────────────────────────────────────────────────────────────
+
+interface IProviderPayloadCacheDocument extends Document {
+  cacheKey: string;
+  provider: ProviderType;
+  payload: Record<string, unknown>;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const ProviderPayloadCacheSchema = new Schema<IProviderPayloadCacheDocument>(
+  {
+    cacheKey: { type: String, required: true, unique: true, index: true },
+    provider: { type: String, enum: Object.values(ProviderType), required: true, index: true },
+    payload: { type: Schema.Types.Mixed, required: true },
+    expiresAt: { type: Date, required: true, index: { expireAfterSeconds: 0 } },
+  },
+  { timestamps: true },
+);
+
+const ProviderPayloadCacheModel = mongoose.model<IProviderPayloadCacheDocument>(
+  'ProviderPayloadCache',
+  ProviderPayloadCacheSchema,
+);
+
+// ── Mongo-backed implementation ────────────────────────────────────────────────
+
+export const DEFAULT_TTL_SECONDS = 3600; // 1 hour
+
+export class MongoProviderPayloadCache implements IProviderPayloadCache {
+  async get(key: string): Promise<Record<string, unknown> | null> {
+    const doc = await ProviderPayloadCacheModel.findOne({
+      cacheKey: key,
+      expiresAt: { $gt: new Date() },
+    }).lean();
+    return doc ? (doc.payload as Record<string, unknown>) : null;
+  }
+
+  async set(key: string, payload: Record<string, unknown>, ttlSeconds = DEFAULT_TTL_SECONDS): Promise<void> {
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+    const [provider] = key.split(':') as [ProviderType];
+    await ProviderPayloadCacheModel.findOneAndUpdate(
+      { cacheKey: key },
+      { cacheKey: key, provider, payload, expiresAt },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+  }
+
+  async invalidate(key: string): Promise<void> {
+    await ProviderPayloadCacheModel.deleteOne({ cacheKey: key });
+  }
+
+  async invalidateByProvider(provider: ProviderType): Promise<void> {
+    await ProviderPayloadCacheModel.deleteMany({ provider });
+  }
+}

--- a/apps/api/src/domains/tracks/track-reference-upsert.service.ts
+++ b/apps/api/src/domains/tracks/track-reference-upsert.service.ts
@@ -1,0 +1,64 @@
+import { ITrackReference, CreateTrackReferenceDto, ProviderType } from '@mixmatch/types';
+import { ITrackReferenceRepository } from '../../repositories/track-reference.repository';
+import {
+  IProviderPayloadCache,
+  buildCacheKey,
+  MongoProviderPayloadCache,
+} from './provider-payload-cache';
+
+export interface TrackReferenceUpsertInput {
+  provider: ProviderType;
+  providerTrackId: string;
+  /** Raw payload from the provider – stored as-is and used to populate fields */
+  rawPayload: Record<string, unknown>;
+  /** Normalized fields derived from rawPayload by the caller */
+  normalized: Omit<CreateTrackReferenceDto, 'provider' | 'providerTrackId' | 'rawPayload'>;
+}
+
+export interface ITrackReferenceUpsertService {
+  upsert(input: TrackReferenceUpsertInput): Promise<ITrackReference>;
+  resolveByProviderKey(provider: ProviderType, providerTrackId: string): Promise<ITrackReference | null>;
+}
+
+export class TrackReferenceUpsertService implements ITrackReferenceUpsertService {
+  constructor(
+    private readonly repo: ITrackReferenceRepository,
+    private readonly cache: IProviderPayloadCache = new MongoProviderPayloadCache(),
+  ) {}
+
+  /**
+   * Upsert a canonical track reference from a provider lookup.
+   * - De-duplicates by (provider, providerTrackId).
+   * - Refreshes mutable fields (previewUrl, artwork, etc.) on every call.
+   * - Caches the raw payload so repeated lookups skip the provider.
+   */
+  async upsert(input: TrackReferenceUpsertInput): Promise<ITrackReference> {
+    const { provider, providerTrackId, rawPayload, normalized } = input;
+
+    const dto: CreateTrackReferenceDto = {
+      provider,
+      providerTrackId,
+      rawPayload,
+      ...normalized,
+    };
+
+    const track = await this.repo.upsert(dto);
+
+    // Refresh cache with latest raw payload
+    const key = buildCacheKey(provider, providerTrackId);
+    await this.cache.set(key, rawPayload);
+
+    return track;
+  }
+
+  /**
+   * Resolve a canonical track reference by provider key.
+   * Returns null when no record exists yet (caller should do a provider lookup first).
+   */
+  async resolveByProviderKey(
+    provider: ProviderType,
+    providerTrackId: string,
+  ): Promise<ITrackReference | null> {
+    return this.repo.findByProviderAndId(provider, providerTrackId);
+  }
+}

--- a/apps/api/src/domains/tracks/track-resolution.controller.ts
+++ b/apps/api/src/domains/tracks/track-resolution.controller.ts
@@ -1,0 +1,76 @@
+import { Request, Response } from 'express';
+import { ProviderType } from '@mixmatch/types';
+import { container } from '../../config/di';
+import { TrackReferenceUpsertService } from './track-reference-upsert.service';
+import { PreviewCapabilityService } from './preview-capability.service';
+import { MongoProviderPayloadCache, buildCacheKey } from './provider-payload-cache';
+import { sendSuccess, sendError } from '../../utils/api-response';
+
+const upsertService = new TrackReferenceUpsertService(
+  container.trackReferenceRepository,
+  new MongoProviderPayloadCache(),
+);
+const previewService = new PreviewCapabilityService();
+
+/**
+ * POST /tracks/resolve
+ *
+ * Accepts { provider, providerTrackId } and returns a canonical track
+ * reference summary with a preview strategy hint.  Idempotent – repeated
+ * calls for the same provider key return the same canonical record.
+ */
+export const resolveTrackReference = async (req: Request, res: Response): Promise<void> => {
+  const { provider, providerTrackId } = req.body as {
+    provider: ProviderType;
+    providerTrackId: string;
+  };
+
+  // 1. Check cache first
+  const cache = new MongoProviderPayloadCache();
+  const cacheKey = buildCacheKey(provider, providerTrackId);
+  const cached = await cache.get(cacheKey);
+
+  // 2. Try to find existing canonical record
+  let track = await upsertService.resolveByProviderKey(provider, providerTrackId);
+
+  if (!track) {
+    if (!cached) {
+      // No record and no cache – caller must supply rawPayload to create one
+      sendError(res, 404, 'Track reference not found. Supply rawPayload to create it.');
+      return;
+    }
+
+    // Re-hydrate from cached raw payload (best-effort)
+    track = await upsertService.upsert({
+      provider,
+      providerTrackId,
+      rawPayload: cached as Record<string, unknown>,
+      normalized: cached as any,
+    });
+  }
+
+  // 3. Resolve preview strategy
+  const platform = (req.query.platform as 'web' | 'mobile') ?? 'web';
+  const market = req.query.market as string | undefined;
+  const capability = previewService.resolve(provider, providerTrackId, track.previewUrl, {
+    platform,
+    market,
+  });
+
+  sendSuccess(res, 200, {
+    track: {
+      id: track.id,
+      provider: track.provider,
+      providerTrackId: track.providerTrackId,
+      title: track.title,
+      artists: track.artists,
+      album: track.album,
+      durationMs: track.durationMs,
+      previewUrl: track.previewUrl,
+      artwork: track.artwork,
+      explicit: track.explicit,
+      ingestedAt: track.ingestedAt,
+    },
+    preview: capability,
+  });
+};

--- a/apps/api/src/domains/tracks/track-resolution.validation.ts
+++ b/apps/api/src/domains/tracks/track-resolution.validation.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { ProviderType } from '@mixmatch/types';
+
+export const resolveTrackReferenceBodySchema = z.object({
+  provider: z.nativeEnum(ProviderType),
+  providerTrackId: z.string().min(1).max(255),
+  /** Optional raw payload – required only when no canonical record exists yet */
+  rawPayload: z.record(z.unknown()).optional(),
+});
+
+export const resolveTrackReferenceQuerySchema = z.object({
+  platform: z.enum(['web', 'mobile']).optional().default('web'),
+  market: z.string().length(2).optional(),
+});

--- a/apps/api/src/domains/tracks/tracks.routes.ts
+++ b/apps/api/src/domains/tracks/tracks.routes.ts
@@ -1,0 +1,56 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireAuth } from '../../middleware/auth.middleware';
+import { validateRequest } from '../../utils/validation';
+import { resolveTrackReference } from './track-resolution.controller';
+import {
+  resolveTrackReferenceBodySchema,
+  resolveTrackReferenceQuerySchema,
+} from './track-resolution.validation';
+import { sendError } from '../../utils/api-response';
+
+// ── Simple in-memory rate limiter (per user, per minute) ──────────────────────
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 60;
+
+const requestCounts = new Map<string, { count: number; resetAt: number }>();
+
+const rateLimiter = (req: Request, res: Response, next: NextFunction): void => {
+  const userId = req.user?.userId ?? req.ip ?? 'anonymous';
+  const now = Date.now();
+  const entry = requestCounts.get(userId);
+
+  if (!entry || now > entry.resetAt) {
+    requestCounts.set(userId, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return next();
+  }
+
+  if (entry.count >= RATE_LIMIT_MAX) {
+    sendError(res, 429, 'Rate limit exceeded. Please wait before retrying.');
+    return;
+  }
+
+  entry.count += 1;
+  next();
+};
+
+// ── Router ─────────────────────────────────────────────────────────────────────
+
+const tracksRouter = Router();
+
+/**
+ * POST /tracks/resolve
+ * Authenticated, rate-limited endpoint for resolving provider IDs to
+ * canonical track references with preview strategy hints.
+ */
+tracksRouter.post(
+  '/resolve',
+  requireAuth,
+  rateLimiter,
+  validateRequest({
+    body: resolveTrackReferenceBodySchema,
+    query: resolveTrackReferenceQuerySchema,
+  }),
+  resolveTrackReference,
+);
+
+export default tracksRouter;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,7 @@ import { journeysRouter, journeyRouter } from './domains/journeys';
 import { discoveryRouter } from './domains/discovery';
 import { paymentsRouter } from './domains/payments';
 import { resonanceRouter } from './domains/resonance';
+import { tracksRouter } from './domains/tracks';
 import { notFoundHandler } from './middleware/not-found.middleware';
 import { errorHandler } from './middleware/error.middleware';
 import { contextMiddleware } from './middleware/context.middleware';
@@ -23,6 +24,7 @@ app.use('/journeys', journeyRouter);
 app.use('/discover', discoveryRouter);
 app.use('/payments', paymentsRouter);
 app.use('/resonance', resonanceRouter);
+app.use('/tracks', tracksRouter);
 
 connectDB();
 


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to @Xhristin3 in a single PR.

---

### #223 – Provider payload cache for track metadata lookups

- New `IProviderPayloadCache` interface (swappable – Redis-ready)
- `MongoProviderPayloadCache` backed by a TTL-indexed Mongo collection (`ProviderPayloadCache`)
- `buildCacheKey(provider, providerTrackId)` helper
- Default TTL: 1 hour; configurable per call
- `invalidate(key)` and `invalidateByProvider(provider)` for targeted cache busting

### #224 – Track reference upsert service from provider lookups

- `TrackReferenceUpsertService` wraps the existing `ITrackReferenceRepository`
- De-duplicates by `(provider, providerTrackId)` via the existing upsert path
- Refreshes mutable fields (previewUrl, artwork, etc.) on every call
- Writes raw payload back to cache after each upsert
- `resolveByProviderKey` for read-only lookups

### #225 – Internal API endpoint for track reference resolution

- `POST /tracks/resolve` – authenticated (`requireAuth`) + rate-limited (60 req/min per user)
- Accepts `{ provider, providerTrackId, rawPayload? }` + optional `?platform` / `?market` query params
- Idempotent: repeated calls for the same provider key return the same canonical record
- Returns canonical track summary + `preview` strategy hint
- Zod validation on both body and query

### #226 – Audio preview capability model and fallback decision service

- `PreviewStrategy` enum: `AUTO_PLAY` | `PROVIDER_HANDOFF` | `SILENT_PLACEHOLDER`
- `AudioPreviewCapability` model (provider, hasPreviewUrl, streamingRestricted, market, strategy)
- `PreviewCapabilityService.resolve()` – pure deterministic function, no I/O
- Streaming restriction rules (e.g. Apple Music web = restricted)
- Strategy is included in every `/tracks/resolve` response

---

Closes #223
Closes #224
Closes #225
Closes #226