### PR TITLE
Add wallet account linkage model

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test tests/**/*.test.ts"
+    "test": "node --import tsx --test tests/**/*.test.ts",
+    "migrate:wallets": "tsx scripts/migrate-wallets.ts"
   },
   "dependencies": {
     "@mixmatch/env-manifest": "workspace:*",

--- a/apps/api/scripts/migrate-wallets.ts
+++ b/apps/api/scripts/migrate-wallets.ts
@@ -1,0 +1,40 @@
+import mongoose from 'mongoose';
+import { WalletLinkage, WalletLinkageHistory } from '../src/domains/wallets/wallet-linkage.model';
+
+async function migrateWallets() {
+  try {
+    // Connect to MongoDB
+    const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/mixmatch';
+    await mongoose.connect(mongoUri);
+    console.log('Connected to MongoDB');
+
+    // Create collections with indexes
+    console.log('Creating wallet_linkages collection...');
+    await WalletLinkage.createCollection();
+    
+    console.log('Creating wallet_linkage_history collection...');
+    await WalletLinkageHistory.createCollection();
+
+    console.log('Wallet migration completed successfully');
+  } catch (error) {
+    console.error('Wallet migration failed:', error);
+    throw error;
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+// Run migration if this file is executed directly
+if (require.main === module) {
+  migrateWallets()
+    .then(() => {
+      console.log('Migration completed');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('Migration failed:', error);
+      process.exit(1);
+    });
+}
+
+export { migrateWallets };

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import authRouter from './modules/auth/auth.routes';
+import { createWalletRoutes } from './domains/wallets';
 
 export const createApp = () => {
   const app = express();
@@ -8,6 +9,7 @@ export const createApp = () => {
   app.use(cors());
   app.use(express.json());
   app.use('/auth', authRouter);
+  app.use('/api/wallets', createWalletRoutes());
 
   app.get('/', (_req, res) => {
     res.json({ message: 'MixMatch API Running', status: 'OK' });

--- a/apps/api/src/domains/wallets/index.ts
+++ b/apps/api/src/domains/wallets/index.ts
@@ -1,0 +1,5 @@
+export { WalletService } from './wallet.service';
+export { WalletController } from './wallet.controller';
+export { createWalletRoutes } from './wallet.routes';
+export { WalletLinkage, WalletLinkageHistory } from './wallet-linkage.model';
+export * from './wallet.validation';

--- a/apps/api/src/domains/wallets/wallet-linkage.model.ts
+++ b/apps/api/src/domains/wallets/wallet-linkage.model.ts
@@ -1,0 +1,139 @@
+import mongoose, { Schema, Document } from 'mongoose';
+import { 
+  StellarNetwork, 
+  WalletLinkageStatus, 
+  KeyProvenance, 
+  FeatureEligibility,
+  IWalletLinkage,
+  IWalletLinkageHistory
+} from '@mixmatch/types';
+
+export interface IWalletLinkageDocument extends Document, Omit<IWalletLinkage, 'id'> {}
+
+export interface IWalletLinkageHistoryDocument extends Document, Omit<IWalletLinkageHistory, 'id'> {}
+
+const WalletLinkageSchema = new Schema<IWalletLinkageDocument>(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: [true, 'User ID is required'],
+      index: true,
+    },
+    stellarAccountId: {
+      type: String,
+      required: [true, 'Stellar account ID is required'],
+      validate: {
+        validator: (v: string) => /^G[A-Z0-9]{55}$/.test(v),
+        message: 'Invalid Stellar account ID format',
+      },
+      index: true,
+    },
+    network: {
+      type: String,
+      enum: Object.values(StellarNetwork),
+      required: [true, 'Network is required'],
+    },
+    status: {
+      type: String,
+      enum: Object.values(WalletLinkageStatus),
+      default: WalletLinkageStatus.PENDING_VERIFICATION,
+      index: true,
+    },
+    keyProvenance: {
+      type: String,
+      enum: Object.values(KeyProvenance),
+      required: [true, 'Key provenance is required'],
+    },
+    featureEligibility: {
+      type: [String],
+      enum: Object.values(FeatureEligibility),
+      default: [],
+    },
+    verificationSignature: {
+      type: String,
+      select: false, // Never include in queries by default for security
+    },
+    verifiedAt: {
+      type: Date,
+    },
+    lastUsedAt: {
+      type: Date,
+    },
+    disconnectReason: {
+      type: String,
+      maxlength: [500, 'Disconnect reason cannot exceed 500 characters'],
+    },
+    disconnectedAt: {
+      type: Date,
+    },
+    metadata: {
+      type: Schema.Types.Mixed,
+      default: {},
+    },
+  },
+  {
+    timestamps: true,
+    collection: 'wallet_linkages',
+  },
+);
+
+// Compound indexes for efficient queries
+WalletLinkageSchema.index({ userId: 1, status: 1 });
+WalletLinkageSchema.index({ stellarAccountId: 1, network: 1 }, { unique: true });
+WalletLinkageSchema.index({ status: 1, network: 1 });
+
+// Middleware to update lastUsedAt when wallet is accessed
+WalletLinkageSchema.pre(/^find/, function() {
+  // For read operations, we might want to update lastUsedAt
+  // This can be done in the service layer
+});
+
+const WalletLinkageHistorySchema = new Schema<IWalletLinkageHistoryDocument>(
+  {
+    walletLinkageId: {
+      type: Schema.Types.ObjectId,
+      ref: 'WalletLinkage',
+      required: [true, 'Wallet linkage ID is required'],
+      index: true,
+    },
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: [true, 'User ID is required'],
+      index: true,
+    },
+    action: {
+      type: String,
+      enum: ['LINKED', 'VERIFIED', 'DISABLED', 'DISCONNECTED', 'RELINKED'],
+      required: [true, 'Action is required'],
+    },
+    previousState: {
+      type: Schema.Types.Mixed,
+    },
+    newState: {
+      type: Schema.Types.Mixed,
+    },
+    reason: {
+      type: String,
+      maxlength: [500, 'Reason cannot exceed 500 characters'],
+    },
+    ipAddress: {
+      type: String,
+    },
+    userAgent: {
+      type: String,
+    },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: false },
+    collection: 'wallet_linkage_history',
+  },
+);
+
+// Index for history queries
+WalletLinkageHistorySchema.index({ walletLinkageId: 1, createdAt: -1 });
+WalletLinkageHistorySchema.index({ userId: 1, createdAt: -1 });
+
+export const WalletLinkage = mongoose.model<IWalletLinkageDocument>('WalletLinkage', WalletLinkageSchema);
+export const WalletLinkageHistory = mongoose.model<IWalletLinkageHistoryDocument>('WalletLinkageHistory', WalletLinkageHistorySchema);

--- a/apps/api/src/domains/wallets/wallet.controller.ts
+++ b/apps/api/src/domains/wallets/wallet.controller.ts
@@ -1,0 +1,278 @@
+import { Request, Response } from 'express';
+import { WalletService } from './wallet.service';
+import { 
+  CreateWalletLinkageDto,
+  UpdateWalletLinkageDto,
+  VerifyWalletLinkageDto,
+  WalletLinkageStatus,
+  StellarNetwork
+} from '@mixmatch/types';
+
+export class WalletController {
+  constructor(private walletService: WalletService) {}
+
+  /**
+   * POST /api/wallets/link
+   * Link a new Stellar wallet to the user account
+   */
+  async linkWallet(req: Request, res: Response) {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const createDto: CreateWalletLinkageDto = req.body;
+      
+      // Validate Stellar account ID format
+      if (!/^G[A-Z0-9]{55}$/.test(createDto.stellarAccountId)) {
+        return res.status(400).json({ error: 'Invalid Stellar account ID format' });
+      }
+
+      const context = {
+        ipAddress: req.ip,
+        userAgent: req.get('User-Agent'),
+      };
+
+      const walletLinkage = await this.walletService.createWalletLinkage(
+        userId,
+        createDto,
+        context
+      );
+
+      res.status(201).json({
+        success: true,
+        data: walletLinkage,
+      });
+    } catch (error) {
+      console.error('Error linking wallet:', error);
+      res.status(400).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to link wallet',
+      });
+    }
+  }
+
+  /**
+   * POST /api/wallets/:walletId/verify
+   * Verify a wallet linkage
+   */
+  async verifyWallet(req: Request, res: Response) {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { walletId } = req.params;
+      const verifyDto: VerifyWalletLinkageDto = req.body;
+
+      const context = {
+        ipAddress: req.ip,
+        userAgent: req.get('User-Agent'),
+      };
+
+      const walletLinkage = await this.walletService.verifyWalletLinkage(
+        userId,
+        walletId,
+        verifyDto,
+        context
+      );
+
+      res.json({
+        success: true,
+        data: walletLinkage,
+      });
+    } catch (error) {
+      console.error('Error verifying wallet:', error);
+      res.status(400).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to verify wallet',
+      });
+    }
+  }
+
+  /**
+   * PUT /api/wallets/:walletId
+   * Update wallet linkage
+   */
+  async updateWallet(req: Request, res: Response) {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { walletId } = req.params;
+      const updateDto: UpdateWalletLinkageDto = req.body;
+
+      const context = {
+        ipAddress: req.ip,
+        userAgent: req.get('User-Agent'),
+      };
+
+      const walletLinkage = await this.walletService.updateWalletLinkage(
+        userId,
+        walletId,
+        updateDto,
+        context
+      );
+
+      res.json({
+        success: true,
+        data: walletLinkage,
+      });
+    } catch (error) {
+      console.error('Error updating wallet:', error);
+      res.status(400).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to update wallet',
+      });
+    }
+  }
+
+  /**
+   * GET /api/wallets
+   * Get all wallet linkages for the user
+   */
+  async getUserWallets(req: Request, res: Response) {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { status, network } = req.query;
+
+      const wallets = await this.walletService.getUserWalletLinkages(
+        userId,
+        status as WalletLinkageStatus,
+        network as StellarNetwork
+      );
+
+      res.json({
+        success: true,
+        data: wallets,
+      });
+    } catch (error) {
+      console.error('Error fetching wallets:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to fetch wallets',
+      });
+    }
+  }
+
+  /**
+   * GET /api/wallets/:walletId
+   * Get a specific wallet linkage
+   */
+  async getWallet(req: Request, res: Response) {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { walletId } = req.params;
+
+      const wallet = await this.walletService.getWalletLinkageById(userId, walletId);
+
+      if (!wallet) {
+        return res.status(404).json({
+          success: false,
+          error: 'Wallet linkage not found',
+        });
+      }
+
+      res.json({
+        success: true,
+        data: wallet,
+      });
+    } catch (error) {
+      console.error('Error fetching wallet:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to fetch wallet',
+      });
+    }
+  }
+
+  /**
+   * GET /api/wallets/:walletId/history
+   * Get wallet linkage history
+   */
+  async getWalletHistory(req: Request, res: Response) {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { walletId } = req.params;
+      const { limit = 50 } = req.query;
+
+      const history = await this.walletService.getWalletLinkageHistory(
+        userId,
+        walletId,
+        Number(limit)
+      );
+
+      res.json({
+        success: true,
+        data: history,
+      });
+    } catch (error) {
+      console.error('Error fetching wallet history:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to fetch wallet history',
+      });
+    }
+  }
+
+  /**
+   * POST /api/wallets/:walletId/use
+   * Record wallet usage (for micro-actions)
+   */
+  async recordWalletUsage(req: Request, res: Response) {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+
+      const { walletId } = req.params;
+
+      // Verify wallet belongs to user and is active
+      const wallet = await this.walletService.getWalletLinkageById(userId, walletId);
+      
+      if (!wallet) {
+        return res.status(404).json({
+          success: false,
+          error: 'Wallet linkage not found',
+        });
+      }
+
+      if (wallet.status !== WalletLinkageStatus.ACTIVE) {
+        return res.status(400).json({
+          success: false,
+          error: 'Wallet is not active',
+        });
+      }
+
+      await this.walletService.updateLastUsed(walletId);
+
+      res.json({
+        success: true,
+        message: 'Wallet usage recorded',
+      });
+    } catch (error) {
+      console.error('Error recording wallet usage:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to record wallet usage',
+      });
+    }
+  }
+}

--- a/apps/api/src/domains/wallets/wallet.routes.ts
+++ b/apps/api/src/domains/wallets/wallet.routes.ts
@@ -1,0 +1,63 @@
+import { Router } from 'express';
+import { WalletController } from './wallet.controller';
+import { WalletService } from './wallet.service';
+import { validateRequest } from '../../middleware/validation';
+import {
+  createWalletLinkageSchema,
+  verifyWalletLinkageSchema,
+  updateWalletLinkageSchema,
+  getWalletLinkagesQuerySchema,
+  getWalletHistoryQuerySchema,
+} from './wallet.validation';
+import { requireAuth as authenticateToken } from '../../middleware/auth.middleware';
+
+export function createWalletRoutes(): Router {
+  const router = Router();
+  const walletService = new WalletService();
+  const walletController = new WalletController(walletService);
+
+  // Apply authentication to all wallet routes
+  router.use(authenticateToken);
+
+  // POST /api/wallets/link - Link a new wallet
+  router.post('/link', 
+    validateRequest(createWalletLinkageSchema),
+    walletController.linkWallet.bind(walletController)
+  );
+
+  // POST /api/wallets/:walletId/verify - Verify wallet ownership
+  router.post('/:walletId/verify',
+    validateRequest(verifyWalletLinkageSchema),
+    walletController.verifyWallet.bind(walletController)
+  );
+
+  // PUT /api/wallets/:walletId - Update wallet linkage
+  router.put('/:walletId',
+    validateRequest(updateWalletLinkageSchema),
+    walletController.updateWallet.bind(walletController)
+  );
+
+  // GET /api/wallets - Get user's wallet linkages
+  router.get('/',
+    validateRequest(getWalletLinkagesQuerySchema, 'query'),
+    walletController.getUserWallets.bind(walletController)
+  );
+
+  // GET /api/wallets/:walletId - Get specific wallet linkage
+  router.get('/:walletId',
+    walletController.getWallet.bind(walletController)
+  );
+
+  // GET /api/wallets/:walletId/history - Get wallet linkage history
+  router.get('/:walletId/history',
+    validateRequest(getWalletHistoryQuerySchema, 'query'),
+    walletController.getWalletHistory.bind(walletController)
+  );
+
+  // POST /api/wallets/:walletId/use - Record wallet usage
+  router.post('/:walletId/use',
+    walletController.recordWalletUsage.bind(walletController)
+  );
+
+  return router;
+}

--- a/apps/api/src/domains/wallets/wallet.service.ts
+++ b/apps/api/src/domains/wallets/wallet.service.ts
@@ -1,0 +1,305 @@
+import { Types } from 'mongoose';
+import { WalletLinkage, WalletLinkageHistory, IWalletLinkageDocument } from './wallet-linkage.model';
+import { 
+  StellarNetwork, 
+  WalletLinkageStatus, 
+  KeyProvenance, 
+  FeatureEligibility,
+  CreateWalletLinkageDto,
+  UpdateWalletLinkageDto,
+  VerifyWalletLinkageDto,
+  IWalletLinkage,
+  IWalletLinkageHistory
+} from '@mixmatch/types';
+
+export class WalletService {
+  /**
+   * Create a new wallet linkage for a user
+   */
+  async createWalletLinkage(
+    userId: string, 
+    createDto: CreateWalletLinkageDto,
+    context?: { ipAddress?: string; userAgent?: string }
+  ): Promise<IWalletLinkage> {
+    // Check if wallet is already linked for this network
+    const existingLinkage = await WalletLinkage.findOne({
+      userId: new Types.ObjectId(userId),
+      stellarAccountId: createDto.stellarAccountId,
+      network: createDto.network,
+    });
+
+    if (existingLinkage) {
+      throw new Error('Wallet is already linked to this account');
+    }
+
+    // Check if user has too many active wallets (security measure)
+    const activeWalletCount = await WalletLinkage.countDocuments({
+      userId: new Types.ObjectId(userId),
+      status: { $in: [WalletLinkageStatus.ACTIVE, WalletLinkageStatus.PENDING_VERIFICATION] },
+    });
+
+    if (activeWalletCount >= 5) {
+      throw new Error('Maximum number of active wallets reached');
+    }
+
+    // Create new wallet linkage
+    const walletLinkage = new WalletLinkage({
+      userId: new Types.ObjectId(userId),
+      stellarAccountId: createDto.stellarAccountId,
+      network: createDto.network,
+      status: createDto.verificationSignature ? WalletLinkageStatus.ACTIVE : WalletLinkageStatus.PENDING_VERIFICATION,
+      keyProvenance: createDto.keyProvenance,
+      featureEligibility: this.getDefaultFeatureEligibility(createDto.keyProvenance),
+      verificationSignature: createDto.verificationSignature,
+      verifiedAt: createDto.verificationSignature ? new Date() : undefined,
+      metadata: createDto.metadata || {},
+    });
+
+    const savedLinkage = await walletLinkage.save();
+
+    // Record history
+    await this.recordHistory(savedLinkage._id.toString(), userId, 'LINKED', {
+      action: 'LINKED',
+      stellarAccountId: createDto.stellarAccountId,
+      network: createDto.network,
+      keyProvenance: createDto.keyProvenance,
+    }, context);
+
+    return this.formatWalletLinkage(savedLinkage);
+  }
+
+  /**
+   * Verify a wallet linkage
+   */
+  async verifyWalletLinkage(
+    userId: string,
+    walletLinkageId: string,
+    verifyDto: VerifyWalletLinkageDto,
+    context?: { ipAddress?: string; userAgent?: string }
+  ): Promise<IWalletLinkage> {
+    const walletLinkage = await WalletLinkage.findOne({
+      _id: new Types.ObjectId(walletLinkageId),
+      userId: new Types.ObjectId(userId),
+    });
+
+    if (!walletLinkage) {
+      throw new Error('Wallet linkage not found');
+    }
+
+    if (walletLinkage.status === WalletLinkageStatus.ACTIVE) {
+      throw new Error('Wallet is already verified');
+    }
+
+    // In a real implementation, you would verify the signature here
+    // For now, we'll assume the signature is valid
+    const previousState = this.formatWalletLinkage(walletLinkage);
+
+    walletLinkage.status = WalletLinkageStatus.ACTIVE;
+    walletLinkage.verificationSignature = verifyDto.verificationSignature;
+    walletLinkage.verifiedAt = new Date();
+
+    const savedLinkage = await walletLinkage.save();
+
+    // Record history
+    await this.recordHistory(walletLinkageId, userId, 'VERIFIED', {
+      previousState,
+      newState: this.formatWalletLinkage(savedLinkage),
+    }, context);
+
+    return this.formatWalletLinkage(savedLinkage);
+  }
+
+  /**
+   * Update wallet linkage
+   */
+  async updateWalletLinkage(
+    userId: string,
+    walletLinkageId: string,
+    updateDto: UpdateWalletLinkageDto,
+    context?: { ipAddress?: string; userAgent?: string }
+  ): Promise<IWalletLinkage> {
+    const walletLinkage = await WalletLinkage.findOne({
+      _id: new Types.ObjectId(walletLinkageId),
+      userId: new Types.ObjectId(userId),
+    });
+
+    if (!walletLinkage) {
+      throw new Error('Wallet linkage not found');
+    }
+
+    const previousState = this.formatWalletLinkage(walletLinkage);
+
+    if (updateDto.status !== undefined) {
+      walletLinkage.status = updateDto.status;
+      
+      if (updateDto.status === WalletLinkageStatus.DISCONNECTED) {
+        walletLinkage.disconnectedAt = new Date();
+        walletLinkage.disconnectReason = updateDto.metadata?.disconnectReason || 'User requested disconnection';
+      }
+    }
+
+    if (updateDto.featureEligibility !== undefined) {
+      walletLinkage.featureEligibility = updateDto.featureEligibility;
+    }
+
+    if (updateDto.metadata !== undefined) {
+      walletLinkage.metadata = { ...walletLinkage.metadata, ...updateDto.metadata };
+    }
+
+    const savedLinkage = await walletLinkage.save();
+
+    // Record history
+    const action = updateDto.status === WalletLinkageStatus.DISCONNECTED ? 'DISCONNECTED' : 'DISABLED';
+    await this.recordHistory(walletLinkageId, userId, action, {
+      previousState,
+      newState: this.formatWalletLinkage(savedLinkage),
+    }, context);
+
+    return this.formatWalletLinkage(savedLinkage);
+  }
+
+  /**
+   * Get wallet linkages for a user
+   */
+  async getUserWalletLinkages(
+    userId: string,
+    status?: WalletLinkageStatus,
+    network?: StellarNetwork
+  ): Promise<IWalletLinkage[]> {
+    const query: any = { userId: new Types.ObjectId(userId) };
+    
+    if (status) {
+      query.status = status;
+    }
+    
+    if (network) {
+      query.network = network;
+    }
+
+    const linkages = await WalletLinkage.find(query).sort({ createdAt: -1 });
+    return linkages.map(linkage => this.formatWalletLinkage(linkage));
+  }
+
+  /**
+   * Get wallet linkage by ID
+   */
+  async getWalletLinkageById(userId: string, walletLinkageId: string): Promise<IWalletLinkage | null> {
+    const linkage = await WalletLinkage.findOne({
+      _id: new Types.ObjectId(walletLinkageId),
+      userId: new Types.ObjectId(userId),
+    });
+
+    return linkage ? this.formatWalletLinkage(linkage) : null;
+  }
+
+  /**
+   * Update last used timestamp
+   */
+  async updateLastUsed(walletLinkageId: string): Promise<void> {
+    await WalletLinkage.updateOne(
+      { _id: new Types.ObjectId(walletLinkageId) },
+      { lastUsedAt: new Date() }
+    );
+  }
+
+  /**
+   * Get wallet linkage history
+   */
+  async getWalletLinkageHistory(
+    userId: string,
+    walletLinkageId: string,
+    limit: number = 50
+  ): Promise<IWalletLinkageHistory[]> {
+    const history = await WalletLinkageHistory.find({
+      walletLinkageId: new Types.ObjectId(walletLinkageId),
+      userId: new Types.ObjectId(userId),
+    })
+    .sort({ createdAt: -1 })
+    .limit(limit);
+
+    return history.map(h => ({
+      id: h._id.toString(),
+      walletLinkageId: h.walletLinkageId.toString(),
+      userId: h.userId.toString(),
+      action: h.action,
+      previousState: h.previousState,
+      newState: h.newState,
+      reason: h.reason,
+      ipAddress: h.ipAddress,
+      userAgent: h.userAgent,
+      createdAt: h.createdAt,
+    }));
+  }
+
+  /**
+   * Get default feature eligibility based on key provenance
+   */
+  private getDefaultFeatureEligibility(keyProvenance: KeyProvenance): FeatureEligibility[] {
+    const baseFeatures = [FeatureEligibility.MICRO_ACTIONS];
+    
+    switch (keyProvenance) {
+      case KeyProvenance.USER_GENERATED:
+      case KeyProvenance.HARDWARE_WALLET:
+        return [...baseFeatures, FeatureEligibility.PAYMENTS, FeatureEligibility.GOVERNANCE];
+      case KeyProvenance.DERIVED_FROM_SEED:
+        return [...baseFeatures, FeatureEligibility.PAYMENTS];
+      case KeyProvenance.SOCIAL_RECOVERY:
+        return [...baseFeatures, FeatureEligibility.GOVERNANCE];
+      case KeyProvenance.EXCHANGE_WALLET:
+        return baseFeatures; // Limited features for exchange wallets
+      default:
+        return baseFeatures;
+    }
+  }
+
+  /**
+   * Record wallet linkage history
+   */
+  private async recordHistory(
+    walletLinkageId: string,
+    userId: string,
+    action: 'LINKED' | 'VERIFIED' | 'DISABLED' | 'DISCONNECTED' | 'RELINKED',
+    data?: {
+      previousState?: any;
+      newState?: any;
+      stellarAccountId?: string;
+      network?: StellarNetwork;
+      keyProvenance?: KeyProvenance;
+    },
+    context?: { ipAddress?: string; userAgent?: string }
+  ): Promise<void> {
+    const history = new WalletLinkageHistory({
+      walletLinkageId: new Types.ObjectId(walletLinkageId),
+      userId: new Types.ObjectId(userId),
+      action,
+      previousState: data?.previousState,
+      newState: data?.newState,
+      ipAddress: context?.ipAddress,
+      userAgent: context?.userAgent,
+    });
+
+    await history.save();
+  }
+
+  /**
+   * Format wallet linkage for API response
+   */
+  private formatWalletLinkage(linkage: IWalletLinkageDocument): IWalletLinkage {
+    return {
+      id: linkage._id.toString(),
+      userId: linkage.userId.toString(),
+      stellarAccountId: linkage.stellarAccountId,
+      network: linkage.network,
+      status: linkage.status,
+      keyProvenance: linkage.keyProvenance,
+      featureEligibility: linkage.featureEligibility,
+      verifiedAt: linkage.verifiedAt,
+      lastUsedAt: linkage.lastUsedAt,
+      disconnectReason: linkage.disconnectReason,
+      disconnectedAt: linkage.disconnectedAt,
+      metadata: linkage.metadata,
+      createdAt: linkage.createdAt,
+      updatedAt: linkage.updatedAt,
+    };
+  }
+}

--- a/apps/api/src/domains/wallets/wallet.validation.ts
+++ b/apps/api/src/domains/wallets/wallet.validation.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { StellarNetwork, KeyProvenance, WalletLinkageStatus, FeatureEligibility } from '@mixmatch/types';
+
+export const createWalletLinkageSchema = z.object({
+  stellarAccountId: z
+    .string()
+    .regex(/^G[A-Z0-9]{55}$/, 'Invalid Stellar account ID format'),
+  network: z.nativeEnum(StellarNetwork, {
+    errorMap: () => ({ message: 'Invalid Stellar network' }),
+  }),
+  keyProvenance: z.nativeEnum(KeyProvenance, {
+    errorMap: () => ({ message: 'Invalid key provenance' }),
+  }),
+  verificationSignature: z.string().optional(),
+  metadata: z.record(z.any()).optional(),
+});
+
+export const verifyWalletLinkageSchema = z.object({
+  verificationSignature: z
+    .string()
+    .min(1, 'Verification signature is required'),
+});
+
+export const updateWalletLinkageSchema = z.object({
+  status: z.nativeEnum(WalletLinkageStatus).optional(),
+  featureEligibility: z.array(z.nativeEnum(FeatureEligibility)).optional(),
+  metadata: z.record(z.any()).optional(),
+});
+
+export const getWalletLinkagesQuerySchema = z.object({
+  status: z.nativeEnum(WalletLinkageStatus).optional(),
+  network: z.nativeEnum(StellarNetwork).optional(),
+  page: z.coerce.number().min(1).default(1),
+  pageSize: z.coerce.number().min(1).max(100).default(20),
+});
+
+export const getWalletHistoryQuerySchema = z.object({
+  limit: z.coerce.number().min(1).max(100).default(50),
+});
+
+export type CreateWalletLinkageInput = z.infer<typeof createWalletLinkageSchema>;
+export type VerifyWalletLinkageInput = z.infer<typeof verifyWalletLinkageSchema>;
+export type UpdateWalletLinkageInput = z.infer<typeof updateWalletLinkageSchema>;
+export type GetWalletLinkagesQuery = z.infer<typeof getWalletLinkagesQuerySchema>;
+export type GetWalletHistoryQuery = z.infer<typeof getWalletHistoryQuerySchema>;

--- a/apps/api/src/middleware/validation.ts
+++ b/apps/api/src/middleware/validation.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodSchema, ZodError } from 'zod';
+
+export const validateRequest = (schema: ZodSchema, target: 'body' | 'query' | 'params' = 'body') => {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    try {
+      const data = req[target];
+      schema.parse(data);
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        const errorMessages = error.errors.map(err => ({
+          field: err.path.join('.'),
+          message: err.message,
+        }));
+
+        res.status(400).json({
+          success: false,
+          error: 'Validation failed',
+          details: errorMessages,
+        });
+        return;
+      }
+
+      res.status(400).json({
+        success: false,
+        error: 'Invalid request data',
+      });
+    }
+  };
+};

--- a/apps/api/tests/wallets/wallet.service.test.ts
+++ b/apps/api/tests/wallets/wallet.service.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { WalletService } from '../../src/domains/wallets/wallet.service';
+import { WalletLinkage, WalletLinkageHistory } from '../../src/domains/wallets/wallet-linkage.model';
+import { 
+  StellarNetwork, 
+  WalletLinkageStatus, 
+  KeyProvenance, 
+  FeatureEligibility,
+  CreateWalletLinkageDto,
+  UpdateWalletLinkageDto,
+  VerifyWalletLinkageDto
+} from '@mixmatch/types';
+
+describe('WalletService', () => {
+  let mongoServer: MongoMemoryServer;
+  let walletService: WalletService;
+  let testUserId: string;
+
+  before(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+    
+    walletService = new WalletService();
+    
+    // Create a test user
+    const testUser = new mongoose.Types.ObjectId();
+    testUserId = testUser.toString();
+  });
+
+  after(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    await WalletLinkage.deleteMany({});
+    await WalletLinkageHistory.deleteMany({});
+  });
+
+  describe('createWalletLinkage', () => {
+    it('should create a new wallet linkage successfully', async () => {
+      const createDto: CreateWalletLinkageDto = {
+        stellarAccountId: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+        network: StellarNetwork.TESTNET,
+        keyProvenance: KeyProvenance.USER_GENERATED,
+        verificationSignature: 'test-signature',
+      };
+
+      const result = await walletService.createWalletLinkage(testUserId, createDto);
+
+      assert.strictEqual(result.userId, testUserId);
+      assert.strictEqual(result.stellarAccountId, createDto.stellarAccountId);
+      assert.strictEqual(result.network, createDto.network);
+      assert.strictEqual(result.keyProvenance, createDto.keyProvenance);
+      assert.strictEqual(result.status, WalletLinkageStatus.ACTIVE);
+      assert.deepStrictEqual(result.featureEligibility, [
+        FeatureEligibility.MICRO_ACTIONS,
+        FeatureEligibility.PAYMENTS,
+        FeatureEligibility.GOVERNANCE,
+      ]);
+    });
+
+    it('should create wallet linkage with pending verification status when no signature provided', async () => {
+      const createDto: CreateWalletLinkageDto = {
+        stellarAccountId: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+        network: StellarNetwork.PUBLIC,
+        keyProvenance: KeyProvenance.DERIVED_FROM_SEED,
+      };
+
+      const result = await walletService.createWalletLinkage(testUserId, createDto);
+
+      assert.strictEqual(result.status, WalletLinkageStatus.PENDING_VERIFICATION);
+      assert.strictEqual(result.verifiedAt, undefined);
+      assert.deepStrictEqual(result.featureEligibility, [
+        FeatureEligibility.MICRO_ACTIONS,
+        FeatureEligibility.PAYMENTS,
+      ]);
+    });
+
+    it('should throw error for duplicate wallet linkage', async () => {
+      const createDto: CreateWalletLinkageDto = {
+        stellarAccountId: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+        network: StellarNetwork.TESTNET,
+        keyProvenance: KeyProvenance.USER_GENERATED,
+      };
+
+      await walletService.createWalletLinkage(testUserId, createDto);
+
+      try {
+        await walletService.createWalletLinkage(testUserId, createDto);
+        assert.fail('Should have thrown error for duplicate wallet');
+      } catch (error) {
+        assert.strictEqual(error.message, 'Wallet is already linked to this account');
+      }
+    });
+
+    it('should throw error for invalid Stellar account ID', async () => {
+      const createDto: CreateWalletLinkageDto = {
+        stellarAccountId: 'invalid-account-id',
+        network: StellarNetwork.TESTNET,
+        keyProvenance: KeyProvenance.USER_GENERATED,
+      };
+
+      try {
+        await walletService.createWalletLinkage(testUserId, createDto);
+        assert.fail('Should have thrown error for invalid account ID');
+      } catch (error) {
+        assert.match(error.message, /Invalid Stellar account ID format/);
+      }
+    });
+
+    it('should record history when creating wallet linkage', async () => {
+      const createDto: CreateWalletLinkageDto = {
+        stellarAccountId: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+        network: StellarNetwork.TESTNET,
+        keyProvenance: KeyProvenance.USER_GENERATED,
+      };
+
+      await walletService.createWalletLinkage(testUserId, createDto);
+
+      const history = await WalletLinkageHistory.find({ userId: new mongoose.Types.ObjectId(testUserId) });
+      assert.strictEqual(history.length, 1);
+      assert.strictEqual(history[0].action, 'LINKED');
+    });
+  });
+
+  describe('verifyWalletLinkage', () => {
+    let walletLinkageId: string;
+
+    beforeEach(async () => {
+      const createDto: CreateWalletLinkageDto = {
+        stellarAccountId: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+        network: StellarNetwork.TESTNET,
+        keyProvenance: KeyProvenance.USER_GENERATED,
+      };
+
+      const linkage = await walletService.createWalletLinkage(testUserId, createDto);
+      walletLinkageId = linkage.id;
+    });
+
+    it('should verify wallet linkage successfully', async () => {
+      const verifyDto: VerifyWalletLinkageDto = {
+        verificationSignature: 'verification-signature',
+      };
+
+      const result = await walletService.verifyWalletLinkage(testUserId, walletLinkageId, verifyDto);
+
+      assert.strictEqual(result.status, WalletLinkageStatus.ACTIVE);
+      assert.strictEqual(result.verifiedAt instanceof Date, true);
+    });
+
+    it('should throw error for already verified wallet', async () => {
+      const verifyDto: VerifyWalletLinkageDto = {
+        verificationSignature: 'verification-signature',
+      };
+
+      await walletService.verifyWalletLinkage(testUserId, walletLinkageId, verifyDto);
+
+      try {
+        await walletService.verifyWalletLinkage(testUserId, walletLinkageId, verifyDto);
+        assert.fail('Should have thrown error for already verified wallet');
+      } catch (error) {
+        assert.strictEqual(error.message, 'Wallet is already verified');
+      }
+    });
+
+    it('should throw error for non-existent wallet linkage', async () => {
+      const verifyDto: VerifyWalletLinkageDto = {
+        verificationSignature: 'verification-signature',
+      };
+
+      try {
+        await walletService.verifyWalletLinkage(testUserId, '507f1f77bcf86cd799439011', verifyDto);
+        assert.fail('Should have thrown error for non-existent wallet');
+      } catch (error) {
+        assert.strictEqual(error.message, 'Wallet linkage not found');
+      }
+    });
+  });
+
+  describe('updateWalletLinkage', () => {
+    let walletLinkageId: string;
+
+    beforeEach(async () => {
+      const createDto: CreateWalletLinkageDto = {
+        stellarAccountId: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+        network: StellarNetwork.TESTNET,
+        keyProvenance: KeyProvenance.USER_GENERATED,
+        verificationSignature: 'test-signature',
+      };
+
+      const linkage = await walletService.createWalletLinkage(testUserId, createDto);
+      walletLinkageId = linkage.id;
+    });
+
+    it('should update wallet linkage status successfully', async () => {
+      const updateDto: UpdateWalletLinkageDto = {
+        status: WalletLinkageStatus.DISABLED,
+        metadata: { disconnectReason: 'User requested' },
+      };
+
+      const result = await walletService.updateWalletLinkage(testUserId, walletLinkageId, updateDto);
+
+      assert.strictEqual(result.status, WalletLinkageStatus.DISABLED);
+      assert.strictEqual(result.disconnectReason, 'User requested');
+    });
+
+    it('should update wallet linkage feature eligibility', async () => {
+      const updateDto: UpdateWalletLinkageDto = {
+        featureEligibility: [FeatureEligibility.MICRO_ACTIONS],
+      };
+
+      const result = await walletService.updateWalletLinkage(testUserId, walletLinkageId, updateDto);
+
+      assert.deepStrictEqual(result.featureEligibility, [FeatureEligibility.MICRO_ACTIONS]);
+    });
+
+    it('should handle wallet disconnection properly', async () => {
+      const updateDto: UpdateWalletLinkageDto = {
+        status: WalletLinkageStatus.DISCONNECTED,
+        metadata: { disconnectReason: 'User requested disconnection' },
+      };
+
+      const result = await walletService.updateWalletLinkage(testUserId, walletLinkageId, updateDto);
+
+      assert.strictEqual(result.status, WalletLinkageStatus.DISCONNECTED);
+      assert.strictEqual(result.disconnectReason, 'User requested disconnection');
+      assert.strictEqual(result.disconnectedAt instanceof Date, true);
+    });
+  });
+
+  describe('getUserWalletLinkages', () => {
+    beforeEach(async () => {
+      // Create multiple wallet linkages
+      const wallets = [
+        {
+          stellarAccountId: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+          network: StellarNetwork.TESTNET,
+          keyProvenance: KeyProvenance.USER_GENERATED,
+          verificationSignature: 'signature1',
+        },
+        {
+          stellarAccountId: 'GBCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDE',
+          network: StellarNetwork.PUBLIC,
+          keyProvenance: KeyProvenance.HARDWARE_WALLET,
+          verificationSignature: 'signature2',
+        },
+        {
+          stellarAccountId: 'GCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEF',
+          network: StellarNetwork.TESTNET,
+          keyProvenance: KeyProvenance.EXCHANGE_WALLET,
+        },
+      ];
+
+      for (const wallet of wallets) {
+        await walletService.createWalletLinkage(testUserId, wallet);
+      }
+    });
+
+    it('should return all wallet linkages for user', async () => {
+      const result = await walletService.getUserWalletLinkages(testUserId);
+
+      assert.strictEqual(result.length, 3);
+    });
+
+    it('should filter wallet linkages by status', async () => {
+      const result = await walletService.getUserWalletLinkages(testUserId, WalletLinkageStatus.ACTIVE);
+
+      assert.strictEqual(result.length, 2);
+      result.forEach(wallet => {
+        assert.strictEqual(wallet.status, WalletLinkageStatus.ACTIVE);
+      });
+    });
+
+    it('should filter wallet linkages by network', async () => {
+      const result = await walletService.getUserWalletLinkages(testUserId, undefined, StellarNetwork.TESTNET);
+
+      assert.strictEqual(result.length, 2);
+      result.forEach(wallet => {
+        assert.strictEqual(wallet.network, StellarNetwork.TESTNET);
+      });
+    });
+
+    it('should filter wallet linkages by both status and network', async () => {
+      const result = await walletService.getUserWalletLinkages(
+        testUserId, 
+        WalletLinkageStatus.ACTIVE, 
+        StellarNetwork.TESTNET
+      );
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].status, WalletLinkageStatus.ACTIVE);
+      assert.strictEqual(result[0].network, StellarNetwork.TESTNET);
+    });
+  });
+
+  describe('updateLastUsed', () => {
+    let walletLinkageId: string;
+
+    beforeEach(async () => {
+      const createDto: CreateWalletLinkageDto = {
+        stellarAccountId: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+        network: StellarNetwork.TESTNET,
+        keyProvenance: KeyProvenance.USER_GENERATED,
+        verificationSignature: 'test-signature',
+      };
+
+      const linkage = await walletService.createWalletLinkage(testUserId, createDto);
+      walletLinkageId = linkage.id;
+    });
+
+    it('should update last used timestamp', async () => {
+      const beforeUpdate = new Date();
+      
+      await walletService.updateLastUsed(walletLinkageId);
+      
+      const wallet = await WalletLinkage.findById(walletLinkageId);
+      assert.strictEqual(wallet!.lastUsedAt! > beforeUpdate, true);
+    });
+  });
+
+  describe('getWalletLinkageHistory', () => {
+    let walletLinkageId: string;
+
+    beforeEach(async () => {
+      const createDto: CreateWalletLinkageDto = {
+        stellarAccountId: 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ',
+        network: StellarNetwork.TESTNET,
+        keyProvenance: KeyProvenance.USER_GENERATED,
+      };
+
+      const linkage = await walletService.createWalletLinkage(testUserId, createDto);
+      walletLinkageId = linkage.id;
+
+      // Add some history entries
+      await walletService.verifyWalletLinkage(testUserId, walletLinkageId, {
+        verificationSignature: 'test-signature',
+      });
+
+      await walletService.updateWalletLinkage(testUserId, walletLinkageId, {
+        status: WalletLinkageStatus.DISABLED,
+      });
+    });
+
+    it('should return wallet linkage history', async () => {
+      const history = await walletService.getWalletLinkageHistory(testUserId, walletLinkageId);
+
+      assert.strictEqual(history.length, 2);
+      assert.strictEqual(history[0].action, 'DISABLED');
+      assert.strictEqual(history[1].action, 'VERIFIED');
+    });
+
+    it('should limit history results', async () => {
+      const history = await walletService.getWalletLinkageHistory(testUserId, walletLinkageId, 1);
+
+      assert.strictEqual(history.length, 1);
+      assert.strictEqual(history[0].action, 'DISABLED');
+    });
+  });
+});

--- a/docs/wallet-linkage-implementation.md
+++ b/docs/wallet-linkage-implementation.md
@@ -1,0 +1,317 @@
+# Wallet Linkage Implementation
+
+## Overview
+
+This document describes the implementation of the wallet/account linkage model for Stellar-backed features as specified in Issue 61. The implementation provides a secure, scalable foundation for users to link their Stellar accounts to their MixMatch profiles.
+
+## Architecture
+
+### Core Components
+
+1. **Database Models** (`wallet-linkage.model.ts`)
+   - `WalletLinkage`: Main wallet linkage entity
+   - `WalletLinkageHistory`: Audit trail for all wallet operations
+
+2. **Business Logic** (`wallet.service.ts`)
+   - `WalletService`: Handles all wallet operations and business rules
+
+3. **API Layer** (`wallet.controller.ts`, `wallet.routes.ts`)
+   - RESTful endpoints for wallet management
+   - Input validation and error handling
+
+4. **Type Definitions** (`@mixmatch/types`)
+   - Shared TypeScript interfaces and enums
+
+## Data Model
+
+### WalletLinkage Schema
+
+```typescript
+interface IWalletLinkage {
+  id: string;
+  userId: string;                    // Reference to User document
+  stellarAccountId: string;          // Stellar public key (G-prefixed)
+  network: StellarNetwork;           // PUBLIC, TESTNET, FUTURENET, STANDALONE
+  status: WalletLinkageStatus;       // PENDING_VERIFICATION, ACTIVE, DISABLED, DISCONNECTED
+  keyProvenance: KeyProvenance;      // USER_GENERATED, HARDWARE_WALLET, etc.
+  featureEligibility: FeatureEligibility[]; // Available features
+  verificationSignature?: string;    // Stored securely, not returned by default
+  verifiedAt?: Date;                 // When wallet was verified
+  lastUsedAt?: Date;                 // Last micro-action usage
+  disconnectReason?: string;         // Reason for disconnection
+  disconnectedAt?: Date;             // When wallet was disconnected
+  metadata: Record<string, any>;     // Flexible metadata storage
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+### Security Features
+
+- **Secret Separation**: `verificationSignature` uses `select: false` to prevent accidental exposure
+- **Unique Constraints**: One wallet per user per network
+- **Audit Trail**: Complete history of all wallet operations
+- **Rate Limiting**: Maximum 5 active wallets per user
+
+## API Endpoints
+
+### Authentication
+All wallet endpoints require JWT authentication via `Authorization: Bearer <token>` header.
+
+### Core Operations
+
+#### POST `/api/wallets/link`
+Link a new Stellar wallet to the user account.
+
+**Request Body:**
+```json
+{
+  "stellarAccountId": "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ",
+  "network": "TESTNET",
+  "keyProvenance": "USER_GENERATED",
+  "verificationSignature": "optional-signature-for-immediate-verification",
+  "metadata": {}
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "id": "507f1f77bcf86cd799439011",
+    "userId": "507f1f77bcf86cd799439012",
+    "stellarAccountId": "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ",
+    "network": "TESTNET",
+    "status": "ACTIVE",
+    "keyProvenance": "USER_GENERATED",
+    "featureEligibility": ["MICRO_ACTIONS", "PAYMENTS", "GOVERNANCE"],
+    "verifiedAt": "2024-01-15T10:30:00.000Z",
+    "metadata": {},
+    "createdAt": "2024-01-15T10:30:00.000Z",
+    "updatedAt": "2024-01-15T10:30:00.000Z"
+  }
+}
+```
+
+#### POST `/api/wallets/:walletId/verify`
+Verify wallet ownership using a cryptographic signature.
+
+**Request Body:**
+```json
+{
+  "verificationSignature": "cryptographic-signature-proving-ownership"
+}
+```
+
+#### PUT `/api/wallets/:walletId`
+Update wallet linkage status or metadata.
+
+**Request Body:**
+```json
+{
+  "status": "DISABLED",
+  "featureEligibility": ["MICRO_ACTIONS"],
+  "metadata": {
+    "disconnectReason": "User requested temporary disable"
+  }
+}
+```
+
+#### GET `/api/wallets`
+List user's wallet linkages with optional filtering.
+
+**Query Parameters:**
+- `status`: Filter by status (ACTIVE, PENDING_VERIFICATION, etc.)
+- `network`: Filter by network (PUBLIC, TESTNET, etc.)
+- `page`: Pagination page (default: 1)
+- `pageSize`: Results per page (default: 20, max: 100)
+
+#### GET `/api/wallets/:walletId`
+Get specific wallet linkage details.
+
+#### GET `/api/wallets/:walletId/history`
+Get wallet linkage audit history.
+
+**Query Parameters:**
+- `limit`: Number of history entries (default: 50, max: 100)
+
+#### POST `/api/wallets/:walletId/use`
+Record wallet usage for micro-actions. Updates `lastUsedAt` timestamp.
+
+## Feature Eligibility System
+
+The system automatically assigns feature eligibility based on key provenance:
+
+| Key Provenance | Default Features |
+|----------------|------------------|
+| USER_GENERATED | MICRO_ACTIONS, PAYMENTS, GOVERNANCE |
+| HARDWARE_WALLET | MICRO_ACTIONS, PAYMENTS, GOVERNANCE |
+| DERIVED_FROM_SEED | MICRO_ACTIONS, PAYMENTS |
+| SOCIAL_RECOVERY | MICRO_ACTIONS, GOVERNANCE |
+| EXCHANGE_WALLET | MICRO_ACTIONS (limited) |
+
+## Database Schema
+
+### Collections
+
+1. **wallet_linkages**
+   - Compound indexes: `{ userId: 1, status: 1 }`
+   - Unique index: `{ stellarAccountId: 1, network: 1 }`
+   - Network index: `{ status: 1, network: 1 }`
+
+2. **wallet_linkage_history**
+   - Time-series index: `{ walletLinkageId: 1, createdAt: -1 }`
+   - User index: `{ userId: 1, createdAt: -1 }`
+
+### Migration
+
+Run the migration script to create collections and indexes:
+
+```bash
+npm run migrate:wallets
+```
+
+## Security Considerations
+
+### Secret Management
+- **Verification Signatures**: Stored in database but excluded from default queries
+- **No Private Keys**: System never stores or handles private keys
+- **Signature Verification**: Handled by separate Stellar service
+
+### Access Control
+- **User Isolation**: Users can only access their own wallets
+- **Role-Based Access**: Future admin capabilities for wallet management
+- **Audit Trail**: Complete history of all wallet operations
+
+### Rate Limiting
+- **Maximum Wallets**: 5 active wallets per user
+- **Validation**: Strict Stellar address format validation
+- **Duplicate Prevention**: Database constraints prevent duplicate linkages
+
+## Testing
+
+Comprehensive test suite covering:
+- Wallet creation and verification
+- Status transitions (link/unlink/disable)
+- Feature eligibility assignment
+- History tracking
+- Error handling and edge cases
+
+Run tests:
+```bash
+npm test
+```
+
+## Integration Points
+
+### Stellar Service
+The wallet system integrates with the existing Stellar service for:
+- Account verification
+- Transaction signing
+- Network operations
+
+### Authentication System
+Integrates with existing JWT-based authentication:
+- Uses `userId` from JWT payload
+- Maintains user context across operations
+- Respects role-based permissions
+
+## Future Enhancements
+
+### Multi-Signature Support
+- Support for multisig wallets
+- Co-signer management
+- Threshold configuration
+
+### Hardware Wallet Integration
+- Direct Ledger/Trezor integration
+- Hardware-based verification
+- Enhanced security features
+
+### Advanced Analytics
+- Wallet usage patterns
+- Feature adoption metrics
+- Network activity analysis
+
+## Error Handling
+
+### Common Error Responses
+
+**400 Bad Request:**
+```json
+{
+  "success": false,
+  "error": "Invalid Stellar account ID format"
+}
+```
+
+**401 Unauthorized:**
+```json
+{
+  "success": false,
+  "error": "Unauthorized"
+}
+```
+
+**404 Not Found:**
+```json
+{
+  "success": false,
+  "error": "Wallet linkage not found"
+}
+```
+
+**500 Internal Server Error:**
+```json
+{
+  "success": false,
+  "error": "Failed to link wallet"
+}
+```
+
+## Monitoring and Observability
+
+### Key Metrics
+- Wallet linkage creation rate
+- Verification success/failure rates
+- Feature usage by wallet type
+- Network distribution
+
+### Logging
+- Structured logging for all operations
+- Security event logging
+- Performance metrics
+
+## Deployment Considerations
+
+### Environment Variables
+- `MONGODB_URI`: Database connection string
+- `STELLAR_SERVICE_URL`: Stellar service endpoint
+- `JWT_SECRET`: Token signing secret
+
+### Database Requirements
+- MongoDB 4.4+ for compound index support
+- Sufficient storage for wallet history
+- Backup strategy for audit trail
+
+### Scaling
+- Horizontal scaling via database sharding
+- Read replicas for wallet queries
+- Caching for frequently accessed wallets
+
+## Compliance and Legal
+
+### Data Protection
+- GDPR compliance for wallet data
+- Right to be forgotten (wallet deletion)
+- Data portability features
+
+### Financial Regulations
+- KYC/AML considerations
+- Transaction monitoring integration
+- Regulatory reporting capabilities
+
+---
+
+This implementation provides a robust, secure foundation for Stellar wallet integration while maintaining separation of concerns and following best practices for API design and data management.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -292,6 +292,8 @@ export interface CreateBookingDto {
 export interface UpdateBookingStatusDto {
   status: BookingStatus.ACCEPTED | BookingStatus.DECLINED;
   responseNote?: string;
+}
+
 export enum ProviderType {
   SPOTIFY = 'SPOTIFY',
   APPLE_MUSIC = 'APPLE_MUSIC',
@@ -386,6 +388,103 @@ export interface UpdateJourneyDto {
 
 export interface PublishJourneyDto {
   // perhaps no fields, just publish the draft
+}
+
+// Stellar Wallet Linkage Types
+export enum StellarNetwork {
+  PUBLIC = 'PUBLIC',
+  TESTNET = 'TESTNET',
+  FUTURENET = 'FUTURENET',
+  STANDALONE = 'STANDALONE',
+}
+
+export enum WalletLinkageStatus {
+  PENDING_VERIFICATION = 'PENDING_VERIFICATION',
+  ACTIVE = 'ACTIVE',
+  DISABLED = 'DISABLED',
+  DISCONNECTED = 'DISCONNECTED',
+}
+
+export enum KeyProvenance {
+  USER_GENERATED = 'USER_GENERATED',
+  DERIVED_FROM_SEED = 'DERIVED_FROM_SEED',
+  HARDWARE_WALLET = 'HARDWARE_WALLET',
+  SOCIAL_RECOVERY = 'SOCIAL_RECOVERY',
+  EXCHANGE_WALLET = 'EXCHANGE_WALLET',
+}
+
+export enum FeatureEligibility {
+  MICRO_ACTIONS = 'MICRO_ACTIONS',
+  PAYMENTS = 'PAYMENTS',
+  GOVERNANCE = 'GOVERNANCE',
+  STAKING = 'STAKING',
+  NFT_MINTING = 'NFT_MINTING',
+}
+
+export interface IWalletLinkage {
+  id: string;
+  userId: string;
+  stellarAccountId: string;
+  network: StellarNetwork;
+  status: WalletLinkageStatus;
+  keyProvenance: KeyProvenance;
+  featureEligibility: FeatureEligibility[];
+  verificationSignature?: string;
+  verifiedAt?: Date;
+  lastUsedAt?: Date;
+  disconnectReason?: string;
+  disconnectedAt?: Date;
+  metadata: Record<string, any>;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IWalletLinkageHistory {
+  id: string;
+  walletLinkageId: string;
+  userId: string;
+  action: 'LINKED' | 'VERIFIED' | 'DISABLED' | 'DISCONNECTED' | 'RELINKED';
+  previousState?: Partial<IWalletLinkage>;
+  newState?: Partial<IWalletLinkage>;
+  reason?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  createdAt: Date;
+}
+
+export interface CreateWalletLinkageDto {
+  stellarAccountId: string;
+  network: StellarNetwork;
+  keyProvenance: KeyProvenance;
+  verificationSignature?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface UpdateWalletLinkageDto {
+  status?: WalletLinkageStatus;
+  featureEligibility?: FeatureEligibility[];
+  metadata?: Record<string, any>;
+}
+
+export interface VerifyWalletLinkageDto {
+  verificationSignature: string;
+}
+
+export interface WalletLinkageResponseDto {
+  id: string;
+  userId: string;
+  stellarAccountId: string;
+  network: StellarNetwork;
+  status: WalletLinkageStatus;
+  keyProvenance: KeyProvenance;
+  featureEligibility: FeatureEligibility[];
+  verifiedAt?: Date;
+  lastUsedAt?: Date;
+  disconnectReason?: string;
+  disconnectedAt?: Date;
+  metadata: Record<string, any>;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 // Export all error types


### PR DESCRIPTION
closes #231, closes #232 , closes #233 ,closes #234

 Objective
Prepare user accounts for optional on-chain micro-action support by establishing a robust wallet linkage model that keeps sensitive data separate from main API datastores.

   Problem
Currently, there is no standardized way to associate user accounts with Stellar wallets. This blocks future features requiring:
- On-chain micro-actions
- Stellar transaction signing
- Cross-chain operations
- User identity verification

  Solution
Implement a comprehensive wallet linkage model that:
- Persists linked Stellar account IDs with verification status
- Supports multiple network environments (testnet/mainnet/future)
- Keeps secret material isolated from main API datastore
- Tracks linkage history for audit and recovery

