### PR TITLE
feat(auth): resolve issues #319 #320 #321 #322

### DIFF
--- a/apps/api/src/config/di.ts
+++ b/apps/api/src/config/di.ts
@@ -1,4 +1,12 @@
-import { MongooseUserRepository, MongooseBookingRepository, MongooseVibeJourneyRepository, MongooseTrackReferenceRepository, MongooseWalletLinkageRepository } from '../repositories';
+import {
+  MongooseUserRepository,
+  MongooseBookingRepository,
+  MongooseVibeJourneyRepository,
+  MongooseTrackReferenceRepository,
+  MongooseWalletLinkageRepository,
+} from '../repositories';
+import { MongooseSessionRepository } from '../repositories/session.repository';
+import { MongooseEmailVerificationTokenRepository } from '../repositories/adapters/mongoose-email-verification-token.repository';
 
 // Simple dependency injection container
 export const container = {
@@ -7,4 +15,6 @@ export const container = {
   vibeJourneyRepository: new MongooseVibeJourneyRepository(),
   trackReferenceRepository: new MongooseTrackReferenceRepository(),
   walletLinkageRepository: new MongooseWalletLinkageRepository(),
+  sessionRepository: new MongooseSessionRepository(),
+  emailVerificationTokenRepository: new MongooseEmailVerificationTokenRepository(),
 };

--- a/apps/api/src/config/observability.ts
+++ b/apps/api/src/config/observability.ts
@@ -29,6 +29,31 @@ const rateLimitStore = new MemoryRateLimitStore();
 export const apiRateLimitMiddleware = createRateLimitMiddleware({
   store: rateLimitStore,
   rules: [
+    // Tighter limits for password-sensitive operations
+    {
+      name: 'auth-change-password',
+      windowMs: 60_000,
+      max: 5,
+      match: (req) => req.method === 'POST' && req.path === '/auth/change-password',
+      skip: isInternalRequest,
+    },
+    // Verification resend — tighter than general auth
+    {
+      name: 'auth-verify-request',
+      windowMs: 60_000,
+      max: 3,
+      match: (req) => req.method === 'POST' && req.path === '/auth/verify/request',
+      skip: isInternalRequest,
+    },
+    // Password reset requests
+    {
+      name: 'auth-reset',
+      windowMs: 60_000,
+      max: 3,
+      match: (req) => req.method === 'POST' && req.path.startsWith('/auth/reset'),
+      skip: isInternalRequest,
+    },
+    // General auth (login/register/logout)
     {
       name: 'auth',
       windowMs: 60_000,

--- a/apps/api/src/domains/identity/auth.controller.ts
+++ b/apps/api/src/domains/identity/auth.controller.ts
@@ -5,11 +5,12 @@ import { container } from "../../config/di";
 import { generateToken } from "../../services/jwt.service";
 import { emailService } from "../../services/email.service";
 import { EmailVerificationService } from "./email-verification.service";
-import { loginSchema, registerSchema } from "./auth.validation";
+import { loginSchema, registerSchema, changePasswordSchema } from "./auth.validation";
 import { AuthenticatedRequestUser } from "../../middleware/auth.middleware";
 import { sendSuccess } from "../../utils/api-response";
 import { AuthError, ValidationError } from "../../utils/errors";
 import { auditLogService } from "../moderation/audit-log.service";
+import { authAuditService } from "../moderation/auth-audit.service";
 import { IUser } from "../../repositories/user.repository";
 
 const SALT_ROUNDS = 10;
@@ -68,11 +69,10 @@ export const register = async (req: Request, res: Response): Promise<void> => {
       .issueToken(createdUser.id, createdUser.email, req.ip, req.headers['user-agent'])
       .catch((err) => console.error('[register] Failed to send verification email:', err));
 
-    const token = generateToken(createdUser.id, createdUser.role as UserRole);
+    const token = generateToken(createdUser.id, createdUser.role as UserRole, '');
 
     sendSuccess(res, 201, {
       token,
-      sessionId: session.sessionId,
       user: serializeUser(createdUser),
     });
   } catch (error) {
@@ -347,4 +347,107 @@ export const logoutAll = async (
   } catch (error) {
     res.status(500).json({ message: "Internal server error" });
   }
+};
+
+/** Max number of previous password hashes to retain for history checks */
+const PASSWORD_HISTORY_LIMIT = 5;
+
+export const changePassword = async (
+  req: Request & { user?: AuthenticatedRequestUser },
+  res: Response,
+): Promise<void> => {
+  if (!req.user?.userId) {
+    res.status(401).json({ message: "Unauthorized" });
+    return;
+  }
+
+  const parsed = changePasswordSchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw ValidationError.invalidInput("body", req.body, "Validation failed");
+  }
+
+  const { currentPassword, newPassword, revokeAllSessions } = parsed.data;
+  const userId = req.user.userId;
+
+  // Fetch user with password history (normally excluded from queries)
+  const user = await container.userRepository.findByIdWithPasswordHistory(userId);
+  if (!user) {
+    res.status(404).json({ message: "User not found" });
+    return;
+  }
+
+  // Verify current password — use a generic error to avoid leaking info
+  const currentMatches = await bcrypt.compare(currentPassword, user.passwordHash);
+  if (!currentMatches) {
+    await authAuditService.log({
+      eventType: 'PASSWORD_CHANGE_FAILED',
+      userId,
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'],
+      metadata: { reason: 'wrong_current_password' },
+    });
+    await auditLogService.log({
+      action: 'PASSWORD_CHANGE_FAILED',
+      actorId: userId,
+      targetId: userId,
+    });
+    throw AuthError.invalidCredentials();
+  }
+
+  // Policy: new password must not match current password
+  const matchesCurrent = await bcrypt.compare(newPassword, user.passwordHash);
+  if (matchesCurrent) {
+    throw ValidationError.invalidInput(
+      "newPassword",
+      "[redacted]",
+      "New password must differ from the current password",
+    );
+  }
+
+  // Policy: new password must not appear in recent history
+  const history = user.passwordHistory ?? [];
+  for (const oldHash of history) {
+    const matchesHistory = await bcrypt.compare(newPassword, oldHash);
+    if (matchesHistory) {
+      throw ValidationError.invalidInput(
+        "newPassword",
+        "[redacted]",
+        `Password was used recently. Choose a password not used in the last ${PASSWORD_HISTORY_LIMIT} changes`,
+      );
+    }
+  }
+
+  const newHash = await bcrypt.hash(newPassword, SALT_ROUNDS);
+
+  // Rotate history: prepend current hash, keep last N
+  const updatedHistory = [user.passwordHash, ...history].slice(0, PASSWORD_HISTORY_LIMIT);
+
+  await container.userRepository.update(userId, {
+    passwordHash: newHash,
+    passwordHistory: updatedHistory,
+  } as any);
+
+  // Optionally revoke all sessions
+  if (revokeAllSessions) {
+    await container.sessionRepository.revokeAllUserSessions(userId);
+  } else if (req.user.sessionId) {
+    // Revoke only the current session so the client must re-authenticate
+    await container.sessionRepository.revokeSession(req.user.sessionId, userId);
+  }
+
+  await authAuditService.log({
+    eventType: 'PASSWORD_CHANGED',
+    userId,
+    ipAddress: req.ip,
+    userAgent: req.headers['user-agent'],
+    metadata: { revokeAllSessions },
+  });
+  await auditLogService.log({
+    action: 'PASSWORD_CHANGED',
+    actorId: userId,
+    targetId: userId,
+    metadata: { revokeAllSessions },
+  });
+
+  sendSuccess(res, 200, { message: "Password changed successfully" });
 };

--- a/apps/api/src/domains/identity/auth.routes.ts
+++ b/apps/api/src/domains/identity/auth.routes.ts
@@ -1,24 +1,64 @@
-import { Router } from 'express';
-import { login, register, updateOnboardingStatus, me, session } from './auth.controller';
+import { Router, Request, Response, NextFunction } from 'express';
+import { login, register, updateOnboardingStatus, me, session, logout, logoutAll, changePassword } from './auth.controller';
+import { requestVerification, confirmVerification, verificationStatus } from './email-verification.controller';
 import { requireAuth } from '../../middleware/auth.middleware';
+import { authCooldownStore } from '../../services/auth-cooldown.service';
+import { noOpRiskCheckService } from '../../services/risk-check.service';
 
 const authRouter = Router();
 
-authRouter.post('/register', register);
-authRouter.post('/login', login);
+// ── Cooldown middleware factory ───────────────────────────────────────────────
+function withCooldown(operation: string) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const identifier = (req.body?.email as string | undefined) ?? req.ip ?? 'unknown';
+    const result = authCooldownStore.check(operation, identifier);
+    if (!result.allowed) {
+      res.set('Retry-After', String(result.retryAfterSeconds ?? 60));
+      res.status(429).json({
+        code: 'COOLDOWN_EXCEEDED',
+        message: 'Too many attempts. Please try again later.',
+        retryAfterSeconds: result.retryAfterSeconds,
+      });
+      return;
+    }
+    next();
+  };
+}
+
+// ── Risk-check middleware factory ─────────────────────────────────────────────
+function withRiskCheck(context: 'signup' | 'login' | 'reset' | 'verify') {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const token = req.body?.captchaToken as string | undefined;
+    const result = await noOpRiskCheckService.assess(context, token, req.ip, req.headers['user-agent']);
+    if (!result.allowed) {
+      res.status(403).json({
+        code: 'RISK_CHECK_FAILED',
+        message: result.reason ?? 'Request blocked by risk assessment',
+      });
+      return;
+    }
+    next();
+  };
+}
+
+// ── Routes ────────────────────────────────────────────────────────────────────
+authRouter.post('/register', withRiskCheck('signup'), withCooldown('signup'), register);
+authRouter.post('/login', withRiskCheck('login'), withCooldown('login'), login);
 authRouter.get('/me', requireAuth, me);
 authRouter.get('/session', requireAuth, session);
 authRouter.patch('/onboarding', requireAuth, updateOnboardingStatus);
 authRouter.post('/logout', requireAuth, logout);
 authRouter.post('/logout-all', requireAuth, logoutAll);
 
-// ── Email Verification ───────────────────────────────────────────────────────
+// ── Password management ───────────────────────────────────────────────────────
+authRouter.post('/change-password', requireAuth, changePassword);
+
+// ── Email Verification ────────────────────────────────────────────────────────
 // POST /auth/verify/request  — issue / re-issue a token (rate-limited)
-authRouter.post('/verify/request', requireAuth, requestVerification);
+authRouter.post('/verify/request', requireAuth, withCooldown('verify'), requestVerification);
 // GET  /auth/verify/confirm?token=<hex>  — consume token, activate account
 authRouter.get('/verify/confirm', confirmVerification);
 // GET  /auth/verify/status  — check current verification state
 authRouter.get('/verify/status', requireAuth, verificationStatus);
 
 export default authRouter;
-

--- a/apps/api/src/domains/identity/auth.validation.ts
+++ b/apps/api/src/domains/identity/auth.validation.ts
@@ -20,6 +20,18 @@ export const confirmTokenSchema = z.object({
     .regex(/^[0-9a-f]+$/, 'Verification token must be a valid hex string'),
 });
 
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, 'Current password is required'),
+  newPassword: z
+    .string()
+    .min(8, 'Password must be at least 8 characters long')
+    .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+    .regex(/[0-9]/, 'Password must contain at least one number'),
+  revokeAllSessions: z.boolean().optional().default(false),
+});
+
+export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
+
 export type RegisterInput = z.infer<typeof registerSchema>;
 export type LoginInput = z.infer<typeof loginSchema>;
 export type ConfirmTokenInput = z.infer<typeof confirmTokenSchema>;

--- a/apps/api/src/domains/identity/user.model.ts
+++ b/apps/api/src/domains/identity/user.model.ts
@@ -16,6 +16,8 @@ export interface IUserDocument extends Document {
   moderationState: ModerationState;
   privacySettings: IPrivacySettings;
   lastActiveAt: Date;
+  /** Last N password hashes for history enforcement */
+  passwordHistory: string[];
   createdAt: Date;
   updatedAt: Date;
 }
@@ -123,6 +125,11 @@ const UserSchema = new Schema<IUserDocument>(
     lastActiveAt: {
       type: Date,
       default: Date.now,
+    },
+    passwordHistory: {
+      type: [String],
+      default: [],
+      select: false, // never returned in queries unless explicitly requested
     },
   },
   {

--- a/apps/api/src/domains/moderation/audit-log.model.ts
+++ b/apps/api/src/domains/moderation/audit-log.model.ts
@@ -9,7 +9,9 @@ export type AuditAction =
   | 'ENTITLEMENT_CONSUMED'
   | 'ACCOUNT_PRIVACY_CHANGED'
   | 'USER_LOGGED_OUT'
-  | 'USER_LOGGED_OUT_ALL';
+  | 'USER_LOGGED_OUT_ALL'
+  | 'PASSWORD_CHANGED'
+  | 'PASSWORD_CHANGE_FAILED';
 
 export interface IAuditLogEntry {
   action: AuditAction;

--- a/apps/api/src/domains/moderation/auth-audit.model.ts
+++ b/apps/api/src/domains/moderation/auth-audit.model.ts
@@ -1,0 +1,54 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export type AuthSecurityEventType =
+  | 'PASSWORD_CHANGED'
+  | 'PASSWORD_CHANGE_FAILED'
+  | 'SUSPICIOUS_LOGIN'
+  | 'ACCOUNT_LOCKED'
+  | 'ACCOUNT_UNLOCKED'
+  | 'RESET_REQUESTED'
+  | 'RESET_COMPLETED'
+  | 'VERIFICATION_ISSUED'
+  | 'VERIFICATION_CONFIRMED'
+  | 'DEVICE_CHANGE_DETECTED'
+  | 'SESSION_REVOKED_ALL';
+
+export type RemediationStatus = 'PENDING' | 'RESOLVED' | 'DISMISSED' | 'ESCALATED';
+
+export interface IAuthAuditEntry {
+  eventType: AuthSecurityEventType;
+  userId: string;
+  /** Truncated/hashed IP summary — never store raw PII */
+  ipSummary?: string;
+  /** UA string (truncated to 256 chars) */
+  deviceFingerprint?: string;
+  remediationStatus: RemediationStatus;
+  metadata?: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface IAuthAuditDocument extends IAuthAuditEntry, Document {}
+
+const AuthAuditSchema = new Schema<IAuthAuditDocument>(
+  {
+    eventType: { type: String, required: true, index: true },
+    userId: { type: String, required: true, index: true },
+    ipSummary: { type: String },
+    deviceFingerprint: { type: String },
+    remediationStatus: {
+      type: String,
+      enum: ['PENDING', 'RESOLVED', 'DISMISSED', 'ESCALATED'] as RemediationStatus[],
+      default: 'PENDING' as RemediationStatus,
+      index: true,
+    },
+    metadata: { type: Schema.Types.Mixed },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } },
+);
+
+// Compound index for querying auth events per user, ordered by time
+AuthAuditSchema.index({ userId: 1, createdAt: -1 });
+// Index for querying unresolved suspicious events
+AuthAuditSchema.index({ eventType: 1, remediationStatus: 1 });
+
+export const AuthAudit = mongoose.model<IAuthAuditDocument>('AuthAudit', AuthAuditSchema);

--- a/apps/api/src/domains/moderation/auth-audit.service.ts
+++ b/apps/api/src/domains/moderation/auth-audit.service.ts
@@ -1,0 +1,55 @@
+import crypto from 'crypto';
+import { AuthAudit, AuthSecurityEventType, IAuthAuditEntry, RemediationStatus } from './auth-audit.model';
+
+export interface AuthAuditParams {
+  eventType: AuthSecurityEventType;
+  userId: string;
+  /** Raw IP address — will be hashed before storage */
+  ipAddress?: string;
+  /** Raw user-agent — will be truncated before storage */
+  userAgent?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** One-way hash of an IP address for storage without storing PII */
+function hashIp(ip: string): string {
+  return crypto.createHash('sha256').update(ip).digest('hex').slice(0, 16);
+}
+
+export class AuthAuditService {
+  async log(params: AuthAuditParams): Promise<void> {
+    const ipSummary = params.ipAddress ? hashIp(params.ipAddress) : undefined;
+    const deviceFingerprint = params.userAgent
+      ? params.userAgent.slice(0, 256)
+      : undefined;
+
+    await AuthAudit.create({
+      eventType: params.eventType,
+      userId: params.userId,
+      ipSummary,
+      deviceFingerprint,
+      remediationStatus: 'PENDING' as RemediationStatus,
+      metadata: params.metadata,
+    });
+  }
+
+  async findByUser(userId: string): Promise<IAuthAuditEntry[]> {
+    return AuthAudit.find({ userId }).sort({ createdAt: -1 }).lean();
+  }
+
+  async findPendingSuspicious(userId: string): Promise<IAuthAuditEntry[]> {
+    return AuthAudit.find({
+      userId,
+      eventType: { $in: ['SUSPICIOUS_LOGIN', 'ACCOUNT_LOCKED', 'DEVICE_CHANGE_DETECTED'] },
+      remediationStatus: 'PENDING',
+    })
+      .sort({ createdAt: -1 })
+      .lean();
+  }
+
+  async updateRemediation(id: string, status: RemediationStatus): Promise<void> {
+    await AuthAudit.findByIdAndUpdate(id, { $set: { remediationStatus: status } });
+  }
+}
+
+export const authAuditService = new AuthAuditService();

--- a/apps/api/src/middleware/auth.middleware.ts
+++ b/apps/api/src/middleware/auth.middleware.ts
@@ -11,6 +11,7 @@ export interface AuthenticatedRequestUser {
   id: string;
   userId: string;
   role: UserRole;
+  sessionId?: string;
   iat?: number;
   exp?: number;
 }
@@ -52,6 +53,7 @@ export const requireAuth = async (req: Request, res: Response, next: NextFunctio
       id: payload.userId,
       userId: payload.userId,
       role: payload.role,
+      sessionId: payload.sessionId,
       iat: payload.iat,
       exp: payload.exp,
     };

--- a/apps/api/src/repositories/adapters/mongoose-user.repository.ts
+++ b/apps/api/src/repositories/adapters/mongoose-user.repository.ts
@@ -18,6 +18,7 @@ const mapToEntity = (doc: any): IUser => ({
   lastActiveAt: doc.lastActiveAt,
   createdAt: doc.createdAt,
   updatedAt: doc.updatedAt,
+  passwordHistory: doc.passwordHistory,
 });
 
 export class MongooseUserRepository implements IUserRepository {
@@ -54,5 +55,10 @@ export class MongooseUserRepository implements IUserRepository {
   async existsByEmail(email: string): Promise<boolean> {
     const count = await User.countDocuments({ email });
     return count > 0;
+  }
+
+  async findByIdWithPasswordHistory(id: string): Promise<IUser | null> {
+    const doc = await User.findById(id).select('+passwordHistory').lean();
+    return doc ? mapToEntity(doc) : null;
   }
 }

--- a/apps/api/src/repositories/user.repository.ts
+++ b/apps/api/src/repositories/user.repository.ts
@@ -17,9 +17,13 @@ export interface IUser {
   lastActiveAt: Date;
   createdAt: Date;
   updatedAt: Date;
+  /** Last N password hashes for history enforcement */
+  passwordHistory?: string[];
 }
 
 export interface IUserRepository extends IRepository<IUser, string> {
   findByEmail(email: string): Promise<IUser | null>;
   existsByEmail(email: string): Promise<boolean>;
+  /** Fetches user including the passwordHistory field (normally excluded). */
+  findByIdWithPasswordHistory(id: string): Promise<IUser | null>;
 }

--- a/apps/api/src/services/auth-cooldown.service.ts
+++ b/apps/api/src/services/auth-cooldown.service.ts
@@ -1,0 +1,94 @@
+import crypto from 'crypto';
+
+export interface CooldownEntry {
+  attempts: number;
+  firstAttemptAt: number;
+  lockedUntil?: number;
+}
+
+export interface CooldownResult {
+  allowed: boolean;
+  /** Seconds until the cooldown expires (only set when allowed=false) */
+  retryAfterSeconds?: number;
+  attempts: number;
+}
+
+export interface AuthCooldownPolicy {
+  /** Rolling window in ms */
+  windowMs: number;
+  /** Max attempts before cooldown is triggered */
+  maxAttempts: number;
+  /** Lockout duration in ms once maxAttempts is exceeded */
+  lockoutMs: number;
+}
+
+const DEFAULT_POLICIES: Record<string, AuthCooldownPolicy> = {
+  signup: { windowMs: 60_000, maxAttempts: 5, lockoutMs: 5 * 60_000 },
+  login: { windowMs: 60_000, maxAttempts: 10, lockoutMs: 15 * 60_000 },
+  verify: { windowMs: 60_000, maxAttempts: 5, lockoutMs: 5 * 60_000 },
+  reset: { windowMs: 60_000, maxAttempts: 3, lockoutMs: 30 * 60_000 },
+};
+
+/**
+ * One-way hash of an identifier (email/IP) so we never store PII in the store.
+ */
+function hashIdentifier(identifier: string): string {
+  return crypto.createHash('sha256').update(identifier).digest('hex');
+}
+
+/**
+ * In-memory cooldown store for per-identifier rate limiting.
+ * In production this should be backed by Redis for multi-instance deployments.
+ */
+export class AuthCooldownStore {
+  private readonly store = new Map<string, CooldownEntry>();
+
+  private key(operation: string, identifier: string): string {
+    return `${operation}:${hashIdentifier(identifier)}`;
+  }
+
+  /**
+   * Record an attempt and check whether the identifier is allowed to proceed.
+   */
+  check(
+    operation: string,
+    identifier: string,
+    policy?: AuthCooldownPolicy,
+  ): CooldownResult {
+    const p = policy ?? DEFAULT_POLICIES[operation] ?? DEFAULT_POLICIES['login'];
+    const k = this.key(operation, identifier);
+    const now = Date.now();
+    const entry = this.store.get(k);
+
+    // Locked out
+    if (entry?.lockedUntil && now < entry.lockedUntil) {
+      const retryAfterSeconds = Math.ceil((entry.lockedUntil - now) / 1000);
+      return { allowed: false, retryAfterSeconds, attempts: entry.attempts };
+    }
+
+    // Window expired — reset
+    if (!entry || now - entry.firstAttemptAt > p.windowMs) {
+      this.store.set(k, { attempts: 1, firstAttemptAt: now });
+      return { allowed: true, attempts: 1 };
+    }
+
+    const attempts = entry.attempts + 1;
+
+    if (attempts > p.maxAttempts) {
+      const lockedUntil = now + p.lockoutMs;
+      this.store.set(k, { ...entry, attempts, lockedUntil });
+      const retryAfterSeconds = Math.ceil(p.lockoutMs / 1000);
+      return { allowed: false, retryAfterSeconds, attempts };
+    }
+
+    this.store.set(k, { ...entry, attempts });
+    return { allowed: true, attempts };
+  }
+
+  /** Reset the cooldown for an identifier (e.g. on successful login) */
+  reset(operation: string, identifier: string): void {
+    this.store.delete(this.key(operation, identifier));
+  }
+}
+
+export const authCooldownStore = new AuthCooldownStore();

--- a/apps/api/src/services/jwt.service.ts
+++ b/apps/api/src/services/jwt.service.ts
@@ -7,6 +7,7 @@ const TOKEN_EXPIRATION = '24h';
 export interface AuthTokenPayload {
   userId: string;
   role: UserRole;
+  sessionId?: string;
   iat?: number;
   exp?: number;
 }

--- a/apps/api/src/services/risk-check.service.ts
+++ b/apps/api/src/services/risk-check.service.ts
@@ -1,0 +1,54 @@
+/**
+ * Risk assessment result returned by any IRiskCheckService implementation.
+ */
+export interface RiskCheckResult {
+  /** Whether the request should be allowed to proceed */
+  allowed: boolean;
+  /** Risk score in [0, 1] — 0 = no risk, 1 = maximum risk */
+  score: number;
+  /** Human-readable reason when allowed=false */
+  reason?: string;
+  /** Provider-specific metadata (e.g. captcha token, challenge ID) */
+  providerMeta?: Record<string, unknown>;
+}
+
+export type RiskCheckContext = 'signup' | 'login' | 'reset' | 'verify';
+
+/**
+ * Abstraction for captcha / risk-assessment providers.
+ * Implement this interface to plug in reCAPTCHA, hCaptcha, Arkose, etc.
+ */
+export interface IRiskCheckService {
+  /**
+   * Assess the risk of an incoming request.
+   *
+   * @param context  - Which auth flow is being protected
+   * @param token    - Client-supplied captcha/challenge token (may be undefined in no-op)
+   * @param ip       - Caller IP address
+   * @param userAgent - Caller user-agent string
+   */
+  assess(
+    context: RiskCheckContext,
+    token: string | undefined,
+    ip: string | undefined,
+    userAgent: string | undefined,
+  ): Promise<RiskCheckResult>;
+}
+
+/**
+ * No-op adapter — always allows requests.
+ * Used in local development and test environments where no captcha vendor is configured.
+ */
+export class NoOpRiskCheckService implements IRiskCheckService {
+  async assess(
+    _context: RiskCheckContext,
+    _token: string | undefined,
+    _ip: string | undefined,
+    _userAgent: string | undefined,
+  ): Promise<RiskCheckResult> {
+    return { allowed: true, score: 0 };
+  }
+}
+
+/** Singleton no-op instance — swap this out in production via DI */
+export const noOpRiskCheckService = new NoOpRiskCheckService();

--- a/apps/api/tests/auth-security.test.ts
+++ b/apps/api/tests/auth-security.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for issues #319, #320, #321, #322:
+ * - #319: change-password endpoint
+ * - #320: auth security audit model
+ * - #321: risk-check service abstraction
+ * - #322: auth-specific rate-limit tiers and cooldown policies
+ */
+import test, { after, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import request from 'supertest';
+
+before(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.JWT_SECRET = 'test-secret-issues';
+  process.env.CORS_ORIGIN = 'http://localhost:3000';
+});
+
+let createApp: typeof import('../src/app').createApp;
+let User: typeof import('../src/domains/identity/user.model').default;
+let mongoose: typeof import('mongoose');
+let MongoMemoryServer: typeof import('mongodb-memory-server').MongoMemoryServer;
+let mongoServer: import('mongodb-memory-server').MongoMemoryServer;
+
+before(async () => {
+  ({ default: mongoose } = await import('mongoose'));
+  ({ MongoMemoryServer } = await import('mongodb-memory-server'));
+
+  mongoServer = await MongoMemoryServer.create({
+    instance: { ip: '127.0.0.1', port: 27085 },
+  });
+
+  process.env.MONGO_URI = mongoServer.getUri();
+
+  ({ createApp } = await import('../src/app'));
+  ({ default: User } = await import('../src/domains/identity/user.model'));
+
+  await mongoose.connect(process.env.MONGO_URI!);
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+});
+
+after(async () => {
+  await mongoose.disconnect();
+  await mongoServer?.stop();
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function registerAndLogin(
+  app: ReturnType<typeof createApp>,
+  email: string,
+  password = 'Password123!',
+) {
+  await request(app)
+    .post('/auth/register')
+    .send({ email, password, role: 'DJ' });
+
+  const loginRes = await request(app)
+    .post('/auth/login')
+    .send({ email, password });
+
+  return loginRes.body.data?.token as string;
+}
+
+// ── Issue #319: change-password ───────────────────────────────────────────────
+
+test('#319 POST /auth/change-password succeeds with valid current password', { concurrency: false }, async () => {
+  const app = createApp();
+  const token = await registerAndLogin(app, 'changepw@example.com');
+
+  const res = await request(app)
+    .post('/auth/change-password')
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      currentPassword: 'Password123!',
+      newPassword: 'NewPassword456!',
+      revokeAllSessions: false,
+    });
+
+  assert.equal(res.status, 200);
+  assert.ok(res.body.data?.message);
+});
+
+test('#319 POST /auth/change-password rejects wrong current password (401)', { concurrency: false }, async () => {
+  const app = createApp();
+  const token = await registerAndLogin(app, 'wrongpw@example.com');
+
+  const res = await request(app)
+    .post('/auth/change-password')
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      currentPassword: 'WrongPassword!',
+      newPassword: 'NewPassword456!',
+    });
+
+  assert.equal(res.status, 401);
+});
+
+test('#319 POST /auth/change-password rejects same password as current', { concurrency: false }, async () => {
+  const app = createApp();
+  const token = await registerAndLogin(app, 'samepw@example.com');
+
+  const res = await request(app)
+    .post('/auth/change-password')
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      currentPassword: 'Password123!',
+      newPassword: 'Password123!',
+    });
+
+  assert.equal(res.status, 422);
+});
+
+test('#319 POST /auth/change-password rejects weak new password', { concurrency: false }, async () => {
+  const app = createApp();
+  const token = await registerAndLogin(app, 'weakpw@example.com');
+
+  const res = await request(app)
+    .post('/auth/change-password')
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      currentPassword: 'Password123!',
+      newPassword: 'weak',
+    });
+
+  assert.equal(res.status, 422);
+});
+
+test('#319 POST /auth/change-password requires authentication', { concurrency: false }, async () => {
+  const app = createApp();
+  const res = await request(app)
+    .post('/auth/change-password')
+    .send({
+      currentPassword: 'Password123!',
+      newPassword: 'NewPassword456!',
+    });
+
+  assert.equal(res.status, 401);
+});
+
+test('#319 POST /auth/change-password with revokeAllSessions=true succeeds', { concurrency: false }, async () => {
+  const app = createApp();
+  const token = await registerAndLogin(app, 'revoke@example.com');
+
+  const res = await request(app)
+    .post('/auth/change-password')
+    .set('Authorization', `Bearer ${token}`)
+    .send({
+      currentPassword: 'Password123!',
+      newPassword: 'NewPassword456!',
+      revokeAllSessions: true,
+    });
+
+  assert.equal(res.status, 200);
+});
+
+// ── Issue #320: auth security audit model ────────────────────────────────────
+
+test('#320 AuthAuditService.log persists an event', { concurrency: false }, async () => {
+  const { authAuditService } = await import('../src/domains/moderation/auth-audit.service');
+  const { AuthAudit } = await import('../src/domains/moderation/auth-audit.model');
+
+  await AuthAudit.deleteMany({});
+
+  await authAuditService.log({
+    eventType: 'PASSWORD_CHANGED',
+    userId: 'user-123',
+    ipAddress: '192.168.1.1',
+    userAgent: 'Mozilla/5.0',
+    metadata: { revokeAllSessions: false },
+  });
+
+  const entries = await authAuditService.findByUser('user-123');
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0]!.eventType, 'PASSWORD_CHANGED');
+  assert.equal(entries[0]!.remediationStatus, 'PENDING');
+  // IP should be hashed, not stored raw
+  assert.notEqual(entries[0]!.ipSummary, '192.168.1.1');
+  assert.ok(entries[0]!.ipSummary, 'ipSummary should be set');
+  // Device fingerprint should be truncated UA
+  assert.ok(entries[0]!.deviceFingerprint?.startsWith('Mozilla'));
+
+  await AuthAudit.deleteMany({});
+});
+
+test('#320 AuthAuditService.findPendingSuspicious returns suspicious events', { concurrency: false }, async () => {
+  const { authAuditService } = await import('../src/domains/moderation/auth-audit.service');
+  const { AuthAudit } = await import('../src/domains/moderation/auth-audit.model');
+
+  await AuthAudit.deleteMany({});
+
+  await authAuditService.log({ eventType: 'SUSPICIOUS_LOGIN', userId: 'user-456' });
+  await authAuditService.log({ eventType: 'PASSWORD_CHANGED', userId: 'user-456' });
+
+  const suspicious = await authAuditService.findPendingSuspicious('user-456');
+  assert.equal(suspicious.length, 1);
+  assert.equal(suspicious[0]!.eventType, 'SUSPICIOUS_LOGIN');
+
+  await AuthAudit.deleteMany({});
+});
+
+// ── Issue #321: risk-check service abstraction ────────────────────────────────
+
+test('#321 NoOpRiskCheckService always allows requests', async () => {
+  const { NoOpRiskCheckService } = await import('../src/services/risk-check.service');
+  const svc = new NoOpRiskCheckService();
+
+  for (const ctx of ['signup', 'login', 'reset', 'verify'] as const) {
+    const result = await svc.assess(ctx, undefined, '1.2.3.4', 'test-agent');
+    assert.equal(result.allowed, true);
+    assert.equal(result.score, 0);
+  }
+});
+
+test('#321 NoOpRiskCheckService works with a captcha token', async () => {
+  const { NoOpRiskCheckService } = await import('../src/services/risk-check.service');
+  const svc = new NoOpRiskCheckService();
+  const result = await svc.assess('signup', 'some-captcha-token', '1.2.3.4', 'agent');
+  assert.equal(result.allowed, true);
+});
+
+test('#321 POST /auth/register passes through no-op risk check', { concurrency: false }, async () => {
+  const app = createApp();
+  const res = await request(app)
+    .post('/auth/register')
+    .send({ email: 'riskcheck@example.com', password: 'Password123!', role: 'DJ' });
+
+  assert.equal(res.status, 201);
+});
+
+// ── Issue #322: auth-specific rate-limit tiers and cooldown policies ──────────
+
+test('#322 AuthCooldownStore allows requests within limit', () => {
+  const { AuthCooldownStore } = require('../src/services/auth-cooldown.service');
+  const store = new AuthCooldownStore();
+
+  for (let i = 0; i < 5; i++) {
+    const result = store.check('login', 'user@example.com');
+    assert.equal(result.allowed, true);
+  }
+});
+
+test('#322 AuthCooldownStore blocks after maxAttempts exceeded', () => {
+  const { AuthCooldownStore } = require('../src/services/auth-cooldown.service');
+  const store = new AuthCooldownStore();
+
+  // login policy: maxAttempts=10
+  for (let i = 0; i < 10; i++) {
+    store.check('login', 'blocked@example.com');
+  }
+  const result = store.check('login', 'blocked@example.com');
+  assert.equal(result.allowed, false);
+  assert.ok(result.retryAfterSeconds && result.retryAfterSeconds > 0);
+});
+
+test('#322 AuthCooldownStore reset clears the cooldown', () => {
+  const { AuthCooldownStore } = require('../src/services/auth-cooldown.service');
+  const store = new AuthCooldownStore();
+
+  for (let i = 0; i < 11; i++) {
+    store.check('login', 'reset@example.com');
+  }
+  store.reset('login', 'reset@example.com');
+  const result = store.check('login', 'reset@example.com');
+  assert.equal(result.allowed, true);
+});
+
+test('#322 AuthCooldownStore hashes identifier (no PII stored)', () => {
+  const { AuthCooldownStore } = require('../src/services/auth-cooldown.service');
+  const store = new AuthCooldownStore();
+
+  store.check('signup', 'sensitive@example.com');
+
+  // The internal store keys should not contain the raw email
+  const keys = Array.from((store as any).store.keys()) as string[];
+  for (const key of keys) {
+    assert.ok(!key.includes('sensitive@example.com'), 'Raw email should not appear in store key');
+  }
+});
+
+test('#322 cooldown middleware returns 429 with Retry-After header', { concurrency: false }, async () => {
+  const app = createApp();
+
+  // signup policy: maxAttempts=5
+  let lastRes: any;
+  for (let i = 0; i < 7; i++) {
+    lastRes = await request(app)
+      .post('/auth/register')
+      .send({ email: 'cooldown@example.com', password: 'Password123!', role: 'DJ' });
+  }
+
+  // After exceeding the cooldown, should get 429 from cooldown middleware
+  // (may also get 429 from global rate limiter — either is acceptable)
+  assert.equal(lastRes.status, 429);
+});


### PR DESCRIPTION
#319 - Add POST /auth/change-password endpoint
- Current-password verification before allowing change
- Policy enforcement: min 8 chars, uppercase, digit required
- Password history checks (last 5 hashes, bcrypt-compared)
- Optional revokeAllSessions flag; always revokes current session
- Structured errors for wrong current password and policy failures

#320 - Add auth security audit model (AuthAudit)
- Dedicated AuthAudit mongoose model separate from generic AuditLog
- Captures: eventType, userId, ipSummary (hashed), deviceFingerprint (truncated UA), remediationStatus
- AuthAuditService with log/findByUser/findPendingSuspicious/updateRemediation
- Compound indexes for per-user queries and unresolved suspicious events
- Also extends AuditAction with PASSWORD_CHANGED / PASSWORD_CHANGE_FAILED

#321 - Add captcha/risk-check service abstraction
- IRiskCheckService interface with assess(context, token, ip, userAgent)
- RiskCheckResult typed response contract (allowed, score, reason, providerMeta)
- NoOpRiskCheckService no-op adapter for local dev (always allows)
- Wired into /register and /login routes via withRiskCheck middleware

#322 - Add auth-specific rate-limit tiers and cooldown policies
- AuthCooldownStore: per-identifier (email/IP) cooldowns with hashed keys
- Per-operation policies: signup(5/min, 5min lockout), login(10/min, 15min), verify(5/min, 5min), reset(3/min, 30min)
- Retry-After header emitted on 429 responses
- Observability rate-limit rules split into per-operation tiers: change-password(5), verify/request(3), reset(3), general auth(8)
- withCooldown middleware wired into register, login, verify/request routes

Also fixes:
- DI container missing sessionRepository and emailVerificationTokenRepository
- AuthenticatedRequestUser missing sessionId field
- AuthTokenPayload missing sessionId field
- auth.controller.ts register() referencing session.sessionId before session creation
- auth.routes.ts missing imports for logout/logoutAll/requestVerification/confirmVerification/verificationStatus



closes #319 
closes #320 
closes #321 
closes #322 