### PR TITLE
Add shared auth contract catalog

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -2,7 +2,10 @@ import cors from "cors";
 import express from "express";
 import helmet from "helmet";
 
-import type { ApiHealthResponse } from "@themixmatch/types";
+import type {
+  ApiHealthResponse,
+  AuthContractCatalogResponse
+} from "@themixmatch/types";
 
 export function createApiApp() {
   const app = express();
@@ -28,6 +31,35 @@ export function createApiApp() {
       milestone: "Authentication",
       nextStep: "Add auth routes, session storage, and shared contracts."
     });
+  });
+
+  app.get("/api/v1/auth/contracts", (_request, response) => {
+    const payload: AuthContractCatalogResponse = {
+      milestone: "Authentication",
+      version: "0.1.0",
+      flows: [
+        {
+          flow: "email-verification",
+          requestType: "EmailVerificationRequest",
+          responseType: "EmailVerificationResponse",
+          owner: "apps/api"
+        },
+        {
+          flow: "password-recovery",
+          requestType: "PasswordRecoveryRequest",
+          responseType: "PasswordRecoveryResponse",
+          owner: "apps/api"
+        },
+        {
+          flow: "ownership-proof",
+          requestType: "OwnershipProofChallengeRequest",
+          responseType: "OwnershipProofChallengeResponse",
+          owner: "apps/api"
+        }
+      ]
+    };
+
+    response.json(payload);
   });
 
   return app;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,3 +17,74 @@ export interface StarterRoadmapCard {
   title: string;
   body: string;
 }
+
+export type AuthContractFlow =
+  | "email-verification"
+  | "password-recovery"
+  | "ownership-proof";
+
+export type AuthContractStatus =
+  | "verification-requested"
+  | "recovery-requested"
+  | "proof-required"
+  | "verified"
+  | "expired";
+
+export interface EmailVerificationRequest {
+  email: string;
+  redirectUrl?: string;
+}
+
+export interface EmailVerificationResponse {
+  flow: "email-verification";
+  status: Extract<AuthContractStatus, "verification-requested">;
+  maskedEmail: string;
+  expiresInSeconds: number;
+}
+
+export interface PasswordRecoveryRequest {
+  email: string;
+  redirectUrl?: string;
+}
+
+export interface PasswordRecoveryResponse {
+  flow: "password-recovery";
+  status: Extract<AuthContractStatus, "recovery-requested">;
+  maskedEmail: string;
+  expiresInSeconds: number;
+}
+
+export interface OwnershipProofChallengeRequest {
+  userId: string;
+  walletPublicKey?: string;
+}
+
+export interface OwnershipProofChallengeResponse {
+  flow: "ownership-proof";
+  status: Extract<AuthContractStatus, "proof-required">;
+  challengeId: string;
+  message: string;
+  expiresInSeconds: number;
+}
+
+export interface OwnershipProofVerificationRequest {
+  challengeId: string;
+  signature: string;
+}
+
+export interface OwnershipProofVerificationResponse {
+  flow: "ownership-proof";
+  status: Extract<AuthContractStatus, "verified" | "expired">;
+  verifiedAt?: string;
+}
+
+export interface AuthContractCatalogResponse {
+  milestone: "Authentication";
+  version: "0.1.0";
+  flows: Array<{
+    flow: AuthContractFlow;
+    requestType: string;
+    responseType: string;
+    owner: "apps/api";
+  }>;
+}


### PR DESCRIPTION
## Problem
The reset API does not yet have shared auth contract names for email verification, password recovery, or ownership proof. That makes it easy for API, web, mobile, and Stellar-adjacent work to drift into app-local request/response shapes.

## Root cause
`packages/types` currently only exposes health/starter types, while `apps/api` advertises Authentication as the next milestone without a discoverable auth contract entry point.

## Approach
- Added shared request/response interfaces for email verification, password recovery, ownership proof challenge, and ownership proof verification.
- Added auth flow/status unions so follow-up implementations reuse the same vocabulary.
- Added `GET /api/v1/auth/contracts` as a read-only API catalog that points contributors to the shared contract type names.
- Kept this intentionally as contracts/catalog work; no email delivery, token generation, session persistence, or wallet signing behavior is introduced in this PR.

## Security review
No secrets, tokens, wallet custody, email sending, or signature verification logic are added here. The new route returns static metadata only. Ownership proof remains explicit as challenge/verification request shapes so future work can validate signatures without storing private keys or conflating email ownership with wallet control.

## Verification
- `npx -y -p typescript@5.9.2 tsc --noEmit --strict packages/types/src/index.ts` -> passed
- `git diff --check` -> passed, with Windows line-ending warnings only

Setup note: the repo currently has no `pnpm-lock.yaml`, so `corepack pnpm install --frozen-lockfile` is blocked. `corepack pnpm install --no-frozen-lockfile` timed out in this environment before it created usable workspace command shims, so I could not run the full workspace `pnpm typecheck` locally.

Fixes #411