### PR TITLE
feat(auth): signup types, service, handler, and regression tests

### DIFF
--- a/apps/api/src/domains/identity/signup.handler.ts
+++ b/apps/api/src/domains/identity/signup.handler.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from "express";
+import { registerSchema } from "./auth.validation";
+import { createAccount, buildSessionBootstrap } from "./signup.service";
+import { sendSuccess } from "../../utils/api-response";
+import { ValidationError } from "../../utils/errors";
+
+/**
+ * POST /api/v1/auth/register
+ *
+ * Validates the request body, delegates account creation to the service layer,
+ * and returns a signed JWT together with the first-session bootstrap payload.
+ * All error states (duplicate email, validation failure, unknown) propagate to
+ * the global error middleware so callers always receive a consistent envelope.
+ */
+export const signupHandler = async (req: Request, res: Response): Promise<void> => {
+  const parsed = registerSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    throw ValidationError.invalidInput("body", req.body, "Validation failed");
+  }
+
+  const authResult = await createAccount(parsed.data);
+  const bootstrap = buildSessionBootstrap(authResult.user.id, authResult.user.role);
+
+  sendSuccess(res, 201, {
+    token: authResult.token,
+    user: authResult.user,
+    session: bootstrap,
+  });
+};
+
+/**
+ * Maps known signup error codes to HTTP status codes.
+ * Used by tests and can be extended for new error variants.
+ */
+export const signupErrorStatus: Record<string, number> = {
+  AUTH_EMAIL_EXISTS: 409,
+  VALIDATION_INVALID_INPUT: 422,
+};

--- a/apps/api/src/domains/identity/signup.service.test.ts
+++ b/apps/api/src/domains/identity/signup.service.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createAccount, buildSessionBootstrap } from "./signup.service";
+import { UserRole } from "@mixmatch/types";
+import { AuthError } from "../../utils/errors";
+
+// ---------------------------------------------------------------------------
+// Shared stubs
+// ---------------------------------------------------------------------------
+
+const mockCreate = vi.fn();
+const mockExistsByEmail = vi.fn();
+
+vi.mock("../../config/di", () => ({
+  container: {
+    userRepository: {
+      existsByEmail: (...args: unknown[]) => mockExistsByEmail(...args),
+      create: (...args: unknown[]) => mockCreate(...args),
+    },
+  },
+}));
+
+vi.mock("../../services/jwt.service", () => ({
+  generateToken: () => "test.jwt.token",
+}));
+
+const baseInput = {
+  email: "dj@example.com",
+  password: "securepass1",
+  role: UserRole.DJ as const,
+};
+
+const fakeUser = {
+  id: "user-1",
+  name: "dj",
+  email: "dj@example.com",
+  role: UserRole.DJ,
+  passwordHash: "hashed",
+  onboardingCompleted: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// ---------------------------------------------------------------------------
+// createAccount – happy path
+// ---------------------------------------------------------------------------
+
+describe("createAccount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExistsByEmail.mockResolvedValue(false);
+    mockCreate.mockResolvedValue(fakeUser);
+  });
+
+  it("returns a token and user on success", async () => {
+    const result = await createAccount(baseInput);
+    expect(result.token).toBe("test.jwt.token");
+    expect(result.user.email).toBe("dj@example.com");
+    expect(result.user.onboardingCompleted).toBe(false);
+  });
+
+  it("normalises email to lowercase", async () => {
+    await createAccount({ ...baseInput, email: "DJ@Example.COM" });
+    expect(mockExistsByEmail).toHaveBeenCalledWith("dj@example.com");
+  });
+
+  it("throws AuthError when email is already taken", async () => {
+    mockExistsByEmail.mockResolvedValue(true);
+    await expect(createAccount(baseInput)).rejects.toThrow(AuthError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSessionBootstrap
+// ---------------------------------------------------------------------------
+
+describe("buildSessionBootstrap", () => {
+  it("returns correct shape for a new user", () => {
+    const bootstrap = buildSessionBootstrap("user-1", UserRole.DJ);
+    expect(bootstrap.userId).toBe("user-1");
+    expect(bootstrap.role).toBe(UserRole.DJ);
+    expect(bootstrap.onboardingCompleted).toBe(false);
+    expect(typeof bootstrap.issuedAt).toBe("string");
+  });
+});

--- a/apps/api/src/domains/identity/signup.service.ts
+++ b/apps/api/src/domains/identity/signup.service.ts
@@ -1,0 +1,62 @@
+import bcrypt from "bcryptjs";
+import { UserRole } from "@mixmatch/types";
+import type { SignupRequest, AuthResponse, SessionBootstrap } from "@mixmatch/types/src/auth";
+import { container } from "../../config/di";
+import { generateToken } from "../../services/jwt.service";
+import { AuthError } from "../../utils/errors";
+
+const SALT_ROUNDS = 10;
+
+const nameFromEmail = (email: string): string =>
+  email.split("@")[0]?.trim() || "mixmatch-user";
+
+/**
+ * Creates a new user account and returns an auth token + user payload.
+ * Throws AuthError.emailAlreadyExists if the address is taken.
+ */
+export async function createAccount(input: SignupRequest): Promise<AuthResponse> {
+  const email = input.email.toLowerCase();
+
+  const taken = await container.userRepository.existsByEmail(email);
+  if (taken) throw AuthError.emailAlreadyExists(email);
+
+  const passwordHash = await bcrypt.hash(input.password, SALT_ROUNDS);
+
+  const user = await container.userRepository.create({
+    name: nameFromEmail(email),
+    email,
+    passwordHash,
+    role: input.role,
+    onboardingCompleted: false,
+  });
+
+  const token = generateToken(user.id, user.role as UserRole);
+
+  return {
+    token,
+    user: {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role as UserRole,
+      onboardingCompleted: user.onboardingCompleted,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    },
+  };
+}
+
+/**
+ * Builds the first-session bootstrap payload from a freshly created user.
+ */
+export function buildSessionBootstrap(
+  userId: string,
+  role: UserRole,
+): SessionBootstrap {
+  return {
+    userId,
+    role,
+    onboardingCompleted: false,
+    issuedAt: new Date().toISOString(),
+  };
+}

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,0 +1,53 @@
+import { UserRole } from "./index";
+
+/** POST /auth/register – request body */
+export interface SignupRequest {
+  email: string;
+  password: string;
+  role: UserRole.DJ | UserRole.PLANNER | UserRole.MUSIC_LOVER;
+}
+
+/** Minimal user shape returned after auth actions */
+export interface AuthUserPayload {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+  onboardingCompleted: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/** Envelope returned by register and login */
+export interface AuthResponse {
+  token: string;
+  user: AuthUserPayload;
+}
+
+/** Generic API success envelope */
+export interface ApiSuccess<T = unknown> {
+  success: true;
+  data: T;
+}
+
+/** Generic API error envelope */
+export interface ApiError {
+  success: false;
+  code: string;
+  message: string;
+}
+
+/** First-session bootstrap payload – sent once after registration */
+export interface SessionBootstrap {
+  userId: string;
+  role: UserRole;
+  onboardingCompleted: boolean;
+  /** ISO timestamp of session creation */
+  issuedAt: string;
+}
+
+/** Union of all auth-related response shapes */
+export type AuthEnvelope =
+  | ApiSuccess<AuthResponse>
+  | ApiSuccess<SessionBootstrap>
+  | ApiError;


### PR DESCRIPTION
Adds the four missing pieces of the registration path:

- **packages/types/src/auth.ts** – shared `SignupRequest`, `AuthResponse`, `SessionBootstrap`, and envelope types (#336)
- **signup.service.ts** – `createAccount` and `buildSessionBootstrap` service functions (#337)
- **signup.handler.ts** – Express handler wiring form submit → JWT + first-session payload (#338)
- **signup.service.test.ts** – happy-path and failure-path regression tests (#339)

Closes #336
Closes #337
Closes #338
Closes #339