### PR TITLE
Shared contract, runtime behaviour

### DIFF
--- a/apps/api/docs/AUTHENTICATION.md
+++ b/apps/api/docs/AUTHENTICATION.md
@@ -2,68 +2,86 @@
 
 ## Overview
 
-This starter implements the first authentication slice with a contract-first API surface and no legacy auth plumbing.
-The auth runtime lives in `apps/api`, and the shared auth contract lives in `packages/types`.
+This starter implements the Authentication milestone with a contract-first API surface. Shared contracts live in `@themixmatch/types`; runtime behavior lives in `apps/api`.
 
-## What matters for contributors
-
-- Shared auth contracts are exported from `@themixmatch/types`.
-- Runtime auth routes are mounted in `apps/api/src/app.ts`.
-- API request validation lives in `apps/api/src/domains/identity/auth.validation.ts`.
-- Auth token generation is handled in `apps/api/src/services/jwt.service.ts`.
-- The current user store is an in-memory repository in `apps/api/src/repositories/user.repository.ts`.
+For the full cross-workspace session lifecycle, see [Session Lifecycle](../../../docs/SESSION_LIFECYCLE.md).
 
 ## Shared contracts
 
-Source:
-- `packages/types/src/auth.ts`
+Source: `packages/types/src/auth.ts`, `packages/types/src/session.types.ts`
 
-Signup DTOs:
-- SignupRequest
-- SignupResponse
-
-Response shapes:
-- `SignupResponse = ApiResponse<SignupResponseData>`
-- `LoginResponse = ApiResponse<LoginResponseData>`
-- `AuthSession = SignupResponseData`
-
-Session DTOs:
-- AuthSession
-- SessionBootstrap
-
-Envelope DTOs:
-- ApiSuccess<T>
-- ApiError
-
-Location:
-packages/types/src/auth.ts
+- `SignupRequest`, `LoginRequest`, `AuthSession`
+- `SessionRefreshRequest`, `SessionRefreshResponse`
+- `IntrospectResponse`
+- `SessionLogoutRequest`, `SessionLogoutResponse`
+- `StellarAuthChallengeRequest/Response`, `StellarAuthVerifyRequest/Response`
+- `ProtectedRouteGuard`, `RefreshTokenRecord`
 
 ## API routes
 
-- POST /api/v1/auth/register — create a new account, return a token, user payload, and session bootstrap.
-- POST /api/v1/auth/login — authenticate an existing account and return the same session-shaped payload.
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/v1/auth/register` | Public | Create account |
+| POST | `/api/v1/auth/login` | Public | Sign in |
+| POST | `/api/v1/auth/refresh` | Public | Rotate refresh token |
+| GET | `/api/v1/auth/introspect` | Protected | Validate access token |
+| POST | `/api/v1/auth/logout` | Public | Revoke refresh token |
+| GET | `/api/v1/auth/handshake` | Public | Stellar handshake metadata |
 
-## Expected response shape
+## Key runtime files
 
-All successful responses use the shared envelope:
+| File | Purpose |
+|------|---------|
+| `src/app.ts` | Route mounting |
+| `src/domains/identity/session.service.ts` | Refresh, introspect, logout logic |
+| `src/domains/identity/session.handler.ts` | HTTP handlers |
+| `src/middleware/require-auth.ts` | Bearer token guard |
+| `src/services/jwt.service.ts` | Access (15m) + refresh (7d) JWT |
+| `src/repositories/refresh-token.repository.ts` | In-memory refresh store |
+
+## Expected response shapes
+
+Success:
 
 ```json
 {
   "success": true,
   "data": {
-    "token": "...",
-    "user": { /* AuthUserPayload */ },
-    "session": { /* SessionBootstrap */ }
+    "accessToken": "...",
+    "refreshToken": "...",
+    "expiresAt": "2026-06-01T12:15:00.000Z"
   }
 }
 ```
 
-Errors use the shared error envelope:
+Error:
 
 ```json
 {
   "success": false,
-  "code": "AUTH_INVALID_CREDENTIALS",
-  "message": "Invalid email or password"
+  "code": "AUTH_UNAUTHORIZED",
+  "message": "Unauthorized"
 }
 ```
+
+## Environment
+
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `JWT_SECRET` | dev secret | Required in production |
+| `STELLAR_SERVICE_URL` | http://localhost:3002 | Stellar proxy target |
+| `PORT` | 3001 | API listen port |
+
+## Run tests
+
+```bash
+pnpm test
+```
+
+Covers refresh rotation, introspection, logout, and `requireAuth` guard paths.
+
+## Open questions
+
+- Refresh store is in-memory — swap for Redis/DB via repository interface
+- Stellar verify is a format stub — on-chain signature validation is a follow-up
+- Role-based route gating available via `requireRole()` — compose after `requireAuth`

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,7 +6,8 @@ import type { ApiHealthResponse } from "@themixmatch/types";
 import { loginHandler } from "./domains/identity/login.handler.js";
 import { signupHandler } from "./domains/identity/signup.handler.js";
 import { stellarAuthVerifyHandler, stellarAuthChallengeHandler } from "./domains/identity/stellar-auth.handler.js";
-import { refreshHandler, introspectHandler } from "./domains/identity/session.handler.js";
+import { refreshHandler, introspectHandler, logoutHandler } from "./domains/identity/session.handler.js";
+import { stellarHandshakeHandler } from "./domains/identity/stellar.handler.js";
 import { requireAuth } from "./middleware/require-auth.js";
 import { sendError } from "./utils/api-response.js";
 
@@ -37,6 +38,8 @@ export function createApiApp(): Application {
         login: "POST /api/v1/auth/login",
         refresh: "POST /api/v1/auth/refresh",
         introspect: "GET /api/v1/auth/introspect",
+        logout: "POST /api/v1/auth/logout",
+        handshake: "GET /api/v1/auth/handshake",
       },
     });
   });
@@ -45,6 +48,8 @@ export function createApiApp(): Application {
   app.post("/api/v1/auth/register", signupHandler);
   app.post("/api/v1/auth/login", loginHandler);
   app.post("/api/v1/auth/refresh", refreshHandler);
+  app.post("/api/v1/auth/logout", logoutHandler);
+  app.get("/api/v1/auth/handshake", stellarHandshakeHandler);
 
   // Stellar-boundary auth routes (auth-to-Stellar handoff)
   app.post("/api/v1/stellar/auth/challenge", stellarAuthChallengeHandler);

--- a/apps/api/src/domains/identity/session.handler.test.ts
+++ b/apps/api/src/domains/identity/session.handler.test.ts
@@ -1,0 +1,112 @@
+import request from "supertest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createApiApp } from "../../app.js";
+import { UserRole } from "@themixmatch/types";
+
+const mockRefreshSession = vi.fn();
+const mockIntrospectSession = vi.fn();
+const mockLogoutSession = vi.fn();
+
+vi.mock("./session.service.js", () => ({
+  refreshSession: (...args: unknown[]) => mockRefreshSession(...args),
+  introspectSession: (...args: unknown[]) => mockIntrospectSession(...args),
+  logoutSession: (...args: unknown[]) => mockLogoutSession(...args),
+}));
+
+const mockRequireAuth = vi.fn((req, res, next) => {
+  const header = req.headers.authorization;
+  if (!header?.startsWith("Bearer ")) {
+    return next({ code: "AUTH_UNAUTHORIZED", message: "Unauthorized", statusCode: 401 });
+  }
+  res.locals.userId = "user-1";
+  res.locals.role = UserRole.DJ;
+  next();
+});
+
+vi.mock("../../middleware/require-auth.js", () => ({
+  requireAuth: (req: unknown, res: unknown, next: unknown) => mockRequireAuth(req, res, next),
+  requireRole: () => (_req: unknown, _res: unknown, next: unknown) => (next as () => void)(),
+}));
+
+const app = createApiApp();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/v1/auth/refresh", () => {
+  it("returns a rotated token pair on success", async () => {
+    mockRefreshSession.mockResolvedValue({
+      accessToken: "new.access.token",
+      refreshToken: "new.refresh.token",
+      expiresAt: "2026-06-01T12:15:00.000Z",
+    });
+
+    const response = await request(app)
+      .post("/api/v1/auth/refresh")
+      .send({ refreshToken: "old.refresh.token" });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      success: true,
+      data: {
+        accessToken: "new.access.token",
+        refreshToken: "new.refresh.token",
+        expiresAt: "2026-06-01T12:15:00.000Z",
+      },
+    });
+  });
+
+  it("returns 422 when refreshToken is missing", async () => {
+    const response = await request(app).post("/api/v1/auth/refresh").send({});
+
+    expect(response.status).toBe(422);
+    expect(response.body.success).toBe(false);
+  });
+});
+
+describe("GET /api/v1/auth/introspect", () => {
+  it("returns valid claims when the access token is accepted", async () => {
+    mockIntrospectSession.mockReturnValue({
+      valid: true,
+      userId: "user-1",
+      role: UserRole.DJ,
+      expiresAt: "2026-06-01T12:15:00.000Z",
+    });
+
+    const response = await request(app)
+      .get("/api/v1/auth/introspect")
+      .set("Authorization", "Bearer valid.access.token");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      success: true,
+      data: {
+        valid: true,
+        userId: "user-1",
+        role: UserRole.DJ,
+        expiresAt: "2026-06-01T12:15:00.000Z",
+      },
+    });
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const response = await request(app).get("/api/v1/auth/introspect");
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+  });
+});
+
+describe("POST /api/v1/auth/logout", () => {
+  it("returns loggedOut on success", async () => {
+    mockLogoutSession.mockResolvedValue({ loggedOut: true });
+
+    const response = await request(app)
+      .post("/api/v1/auth/logout")
+      .send({ refreshToken: "refresh.token" });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true, data: { loggedOut: true } });
+  });
+});

--- a/apps/api/src/domains/identity/session.handler.ts
+++ b/apps/api/src/domains/identity/session.handler.ts
@@ -7,7 +7,7 @@
 
 import type { Request, Response } from "express";
 import { z } from "zod";
-import { refreshSession, introspectSession } from "./session.service.js";
+import { refreshSession, introspectSession, logoutSession } from "./session.service.js";
 import { sendSuccess } from "../../utils/api-response.js";
 import { ValidationError } from "../../utils/errors.js";
 
@@ -24,6 +24,18 @@ export const refreshHandler = async (req: Request, res: Response): Promise<void>
   }
 
   const result = await refreshSession(parsed.data.refreshToken);
+  sendSuccess(res, 200, result);
+};
+
+// ── POST /api/v1/auth/logout ──────────────────────────────────────────────────
+
+export const logoutHandler = async (req: Request, res: Response): Promise<void> => {
+  const parsed = refreshBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    throw ValidationError.invalidInput("body", req.body, "refreshToken is required");
+  }
+
+  const result = await logoutSession(parsed.data.refreshToken);
   sendSuccess(res, 200, result);
 };
 

--- a/apps/api/src/domains/identity/session.service.test.ts
+++ b/apps/api/src/domains/identity/session.service.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UserRole } from "@themixmatch/types";
+import { refreshSession, introspectSession, logoutSession } from "./session.service.js";
+import { AuthError } from "../../utils/errors.js";
+
+const mockFindByJti = vi.fn();
+const mockRevoke = vi.fn();
+const mockSave = vi.fn();
+
+vi.mock("../../config/di.js", () => ({
+  container: {
+    refreshTokenRepository: {
+      findByJti: (...args: unknown[]) => mockFindByJti(...args),
+      revoke: (...args: unknown[]) => mockRevoke(...args),
+      save: (...args: unknown[]) => mockSave(...args),
+    },
+  },
+}));
+
+const mockVerifyRefreshToken = vi.fn();
+const mockVerifyAccessToken = vi.fn();
+const mockGenerateAccessToken = vi.fn();
+const mockGenerateRefreshToken = vi.fn();
+const mockAccessTokenExpiresAt = vi.fn();
+
+vi.mock("../../services/jwt.service.js", () => ({
+  verifyRefreshToken: (...args: unknown[]) => mockVerifyRefreshToken(...args),
+  verifyAccessToken: (...args: unknown[]) => mockVerifyAccessToken(...args),
+  generateAccessToken: (...args: unknown[]) => mockGenerateAccessToken(...args),
+  generateRefreshToken: (...args: unknown[]) => mockGenerateRefreshToken(...args),
+  accessTokenExpiresAt: (...args: unknown[]) => mockAccessTokenExpiresAt(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAccessTokenExpiresAt.mockReturnValue("2026-06-01T12:15:00.000Z");
+});
+
+describe("refreshSession", () => {
+  it("returns a rotated token pair when the refresh token is valid", async () => {
+    mockVerifyRefreshToken.mockReturnValue({ userId: "user-1", role: UserRole.DJ, jti: "jti-1" });
+    mockFindByJti.mockResolvedValue({
+      jti: "jti-1",
+      userId: "user-1",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      revoked: false,
+    });
+    mockGenerateAccessToken.mockReturnValue("new.access.token");
+    mockGenerateRefreshToken.mockReturnValue({ token: "new.refresh.token", jti: "jti-2" });
+
+    const result = await refreshSession("valid.refresh.token");
+
+    expect(result).toEqual({
+      accessToken: "new.access.token",
+      refreshToken: "new.refresh.token",
+      expiresAt: "2026-06-01T12:15:00.000Z",
+    });
+    expect(mockRevoke).toHaveBeenCalledWith("jti-1");
+    expect(mockSave).toHaveBeenCalledWith(expect.objectContaining({ jti: "jti-2", userId: "user-1" }));
+  });
+
+  it("throws unauthorized when the refresh token is revoked", async () => {
+    mockVerifyRefreshToken.mockReturnValue({ userId: "user-1", role: UserRole.DJ, jti: "jti-1" });
+    mockFindByJti.mockResolvedValue({
+      jti: "jti-1",
+      userId: "user-1",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      revoked: true,
+    });
+
+    await expect(refreshSession("revoked.refresh.token")).rejects.toMatchObject({
+      code: AuthError.unauthorized().code,
+      statusCode: 401,
+    });
+  });
+});
+
+describe("introspectSession", () => {
+  it("returns valid claims for a good access token", () => {
+    mockVerifyAccessToken.mockReturnValue({ userId: "user-1", role: UserRole.PLANNER });
+
+    expect(introspectSession("valid.access.token")).toEqual({
+      valid: true,
+      userId: "user-1",
+      role: UserRole.PLANNER,
+      expiresAt: "2026-06-01T12:15:00.000Z",
+    });
+  });
+
+  it("returns valid:false for an invalid access token", () => {
+    mockVerifyAccessToken.mockImplementation(() => {
+      throw new Error("invalid token");
+    });
+
+    expect(introspectSession("bad.access.token")).toEqual({ valid: false });
+  });
+});
+
+describe("logoutSession", () => {
+  it("revokes the refresh token and reports loggedOut", async () => {
+    mockVerifyRefreshToken.mockReturnValue({ userId: "user-1", role: UserRole.DJ, jti: "jti-1" });
+
+    await expect(logoutSession("valid.refresh.token")).resolves.toEqual({ loggedOut: true });
+    expect(mockRevoke).toHaveBeenCalledWith("jti-1");
+  });
+
+  it("still reports loggedOut when the refresh token is invalid", async () => {
+    mockVerifyRefreshToken.mockImplementation(() => {
+      throw new Error("invalid token");
+    });
+
+    await expect(logoutSession("bad.refresh.token")).resolves.toEqual({ loggedOut: true });
+  });
+});

--- a/apps/api/src/domains/identity/session.service.ts
+++ b/apps/api/src/domains/identity/session.service.ts
@@ -72,7 +72,20 @@ export async function refreshSession(rawToken: string): Promise<SessionRefreshRe
   };
 }
 
-// ── Introspect ────────────────────────────────────────────────────────────────
+/**
+ * Revokes the refresh token associated with a logout request.
+ * Idempotent — unknown or already-revoked tokens still return success.
+ */
+export async function logoutSession(rawToken: string): Promise<{ loggedOut: boolean }> {
+  try {
+    const payload = verifyRefreshToken(rawToken);
+    await container.refreshTokenRepository.revoke(payload.jti);
+  } catch {
+    // Token already invalid — treat logout as successful for the client
+  }
+
+  return { loggedOut: true };
+}
 
 /**
  * Validates an access token and returns its claims.

--- a/apps/api/src/domains/identity/stellar-auth.handler.ts
+++ b/apps/api/src/domains/identity/stellar-auth.handler.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from "express";
 import { z } from "zod";
 
+const STELLAR_SERVICE_URL = (process.env.STELLAR_SERVICE_URL ?? "http://localhost:3002").replace(/\/$/, "");
+
 const stellarVerifySchema = z.object({
   sessionToken: z.string().min(1, "Session token is required"),
   stellarPublicKey: z.string().min(1, "Stellar public key is required"),
@@ -16,16 +18,15 @@ export async function stellarAuthVerifyHandler(req: Request, res: Response): Pro
     res.status(422).json({
       success: false,
       code: "VALIDATION_ERROR",
-      message: parsed.error.errors[0]?.message ?? "Invalid input",
+      message: parsed.error.issues[0]?.message ?? "Invalid input",
     });
     return;
   }
 
   const { sessionToken, stellarPublicKey } = parsed.data;
 
-  // Forward to Stellar service for boundary verification
   try {
-    const response = await fetch(`http://localhost:3002/api/v1/stellar/auth/verify`, {
+    const response = await fetch(`${STELLAR_SERVICE_URL}/api/v1/stellar/auth/verify`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ sessionToken, stellarPublicKey }),
@@ -33,7 +34,7 @@ export async function stellarAuthVerifyHandler(req: Request, res: Response): Pro
 
     const data = await response.json();
     res.status(response.status).json(data);
-  } catch (error) {
+  } catch {
     res.status(502).json({
       success: false,
       code: "STELLAR_SERVICE_UNAVAILABLE",
@@ -56,13 +57,13 @@ export async function stellarAuthChallengeHandler(req: Request, res: Response): 
     res.status(422).json({
       success: false,
       code: "VALIDATION_ERROR",
-      message: parsed.error.errors[0]?.message ?? "Invalid input",
+      message: parsed.error.issues[0]?.message ?? "Invalid input",
     });
     return;
   }
 
   try {
-    const response = await fetch(`http://localhost:3002/api/v1/stellar/auth/challenge`, {
+    const response = await fetch(`${STELLAR_SERVICE_URL}/api/v1/stellar/auth/challenge`, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(parsed.data),
@@ -70,7 +71,7 @@ export async function stellarAuthChallengeHandler(req: Request, res: Response): 
 
     const data = await response.json();
     res.status(response.status).json(data);
-  } catch (error) {
+  } catch {
     res.status(502).json({
       success: false,
       code: "STELLAR_SERVICE_UNAVAILABLE",

--- a/apps/api/src/middleware/require-auth.test.ts
+++ b/apps/api/src/middleware/require-auth.test.ts
@@ -1,0 +1,85 @@
+import request from "supertest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import { UserRole } from "@themixmatch/types";
+import { requireAuth, requireRole } from "./require-auth.js";
+import { sendError } from "../utils/api-response.js";
+
+const mockVerifyAccessToken = vi.fn();
+
+vi.mock("../services/jwt.service.js", () => ({
+  verifyAccessToken: (...args: unknown[]) => mockVerifyAccessToken(...args),
+}));
+
+function createTestApp() {
+  const app = express();
+  app.get("/protected", requireAuth, (_req, res) => {
+    res.json({ ok: true, userId: res.locals.userId, role: res.locals.role });
+  });
+  app.get("/dj-only", requireAuth, requireRole(UserRole.DJ), (_req, res) => {
+    res.json({ ok: true });
+  });
+  app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    if (err && typeof err === "object" && "code" in err && "message" in err && "statusCode" in err) {
+      sendError(res, err as { code: string; message: string; statusCode: number });
+    } else {
+      sendError(res, { code: "INTERNAL_ERROR", message: "Unexpected error", statusCode: 500 });
+    }
+  });
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("requireAuth", () => {
+  it("allows access when the bearer token is valid", async () => {
+    mockVerifyAccessToken.mockReturnValue({ userId: "user-1", role: UserRole.DJ });
+    const app = createTestApp();
+
+    const response = await request(app)
+      .get("/protected")
+      .set("Authorization", "Bearer valid.token");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true, userId: "user-1", role: UserRole.DJ });
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const app = createTestApp();
+
+    const response = await request(app).get("/protected");
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+  });
+
+  it("returns 401 when the bearer token is invalid", async () => {
+    mockVerifyAccessToken.mockImplementation(() => {
+      throw new Error("invalid token");
+    });
+    const app = createTestApp();
+
+    const response = await request(app)
+      .get("/protected")
+      .set("Authorization", "Bearer bad.token");
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+  });
+});
+
+describe("requireRole", () => {
+  it("returns 401 when the user role is not allowed", async () => {
+    mockVerifyAccessToken.mockReturnValue({ userId: "user-1", role: UserRole.MUSIC_LOVER });
+    const app = createTestApp();
+
+    const response = await request(app)
+      .get("/dj-only")
+      .set("Authorization", "Bearer valid.token");
+
+    expect(response.status).toBe(401);
+    expect(response.body.success).toBe(false);
+  });
+});

--- a/apps/mobile/docs/MOBILE_AUTH_SETUP.md
+++ b/apps/mobile/docs/MOBILE_AUTH_SETUP.md
@@ -2,92 +2,65 @@
 
 ## Overview
 
-The Expo mobile app (`apps/mobile`) provides a cross-platform authentication surface for iOS and Android. It supports registration, login, session persistence via `expo-secure-store`, and automatic session restoration on launch.
+The mobile app mirrors the web session seam: introspect on launch, refresh when needed, and shared `ProtectedRouteGuard` evaluation.
 
-## Auth Contracts
+See [Session Lifecycle](../../../docs/SESSION_LIFECYCLE.md) for the full lifecycle guide.
 
-| Contract               | Source                                      | Description                              |
-|------------------------|---------------------------------------------|------------------------------------------|
-| `SignupRequest`        | `@themixmatch/types` (AuthUserPayload)       | Registration payload (email, password, role) |
-| `LoginRequest`         | `@themixmatch/types`                        | Login payload (email, password)           |
-| `AuthSession`          | `@themixmatch/types`                        | Stored session (token, user, session meta) |
-| `CredentialErrorCode`  | `@themixmatch/types`                        | Error codes: INVALID_CREDENTIALS, ACCOUNT_NOT_FOUND, ACCOUNT_LOCKED |
-| `AuthClientError`      | `src/auth/authClient.ts`                    | Client-side error wrapper with kind, status, code |
+## Auth contracts
+
+| Contract | Source |
+|----------|--------|
+| `AuthSession`, refresh/introspect/logout types | `@themixmatch/types` |
+| `ProtectedRouteGuard` | `@themixmatch/types` (session.types.ts) |
+| `SessionContinuityOutcome` | `@themixmatch/types` |
 
 ## Routes
 
-| Path       | Screen       | Auth required | Description                     |
-|------------|--------------|---------------|---------------------------------|
-| `/`        | HomeScreen   | No            | Entry point, session check      |
-| `/register`| RegisterScreen | No           | Role selection → `/signup`      |
-| `/signup`  | SignupScreen  | No           | Email/password registration     |
-| `/login`   | LoginScreen   | No           | Email/password sign-in          |
-
-## Dependencies
-
-- `expo-secure-store` — encrypted key-value storage for session tokens
-- `expo-router` — file-based navigation
+| Path | Screen | Auth required |
+|------|--------|---------------|
+| `/` | HomeScreen | No (shows session state) |
+| `/login` | LoginScreen | No |
+| `/signup` | SignupScreen | No |
 
 ## Environment
 
-| Variable                    | Required | Default               | Description                           |
-|-----------------------------|----------|-----------------------|---------------------------------------|
-| `EXPO_PUBLIC_API_BASE_URL`  | No       | `http://localhost:3001`| Backend API root (omit for local mock) |
+| Variable | Default | Notes |
+|----------|---------|-------|
+| `EXPO_PUBLIC_API_BASE_URL` | unset | Omit for local mock; set to `http://localhost:3001` for API |
 
-When `EXPO_PUBLIC_API_BASE_URL` is **not** set, the auth client uses a local in-memory fallback that generates sessions without a server.
+## Key files
 
-## Running the Flow
+```
+apps/mobile/src/auth/
+├── authClient.ts           # register, login, refresh, introspect, logout
+├── AuthProvider.tsx        # session continuity on launch
+├── authStorage.ts          # expo-secure-store
+├── sessionContinuity.ts    # shared seam (mirrors web)
+```
+
+## Exercise the flow
+
+1. Start API: `cd apps/api && pnpm dev`
+2. Start mobile: `cd apps/mobile && pnpm dev`
+3. Sign in → session persisted in SecureStore
+4. Relaunch app → session restored via introspect/refresh
+5. Sign out → refresh token revoked, storage cleared
+
+## Run tests
 
 ```bash
-# Terminal 1: start the API server
-cd apps/api && pnpm dev     # → http://localhost:3001
-
-# Terminal 2: start Expo
-cd apps/mobile && pnpm dev  # → Expo Go / simulator
-```
-
-1. Open the app → see HomeScreen
-2. Tap **Sign in** → LoginScreen
-3. Enter email + password → tap **Sign in**
-4. On success → redirected to HomeScreen (signed-in state)
-5. Tap **Sign out** → session cleared
-
-## Key Files
-
-```
-apps/mobile/
-├── app/
-│   ├── _layout.tsx         # Root layout: AuthProvider + Stack navigator
-│   ├── index.tsx           # HomeScreen: session-aware entry point
-│   ├── login.tsx           # LoginScreen: email/password form
-│   ├── register.tsx        # RegisterScreen: role selection
-│   └── signup.tsx          # SignupScreen: registration form
-├── src/auth/
-│   ├── AuthProvider.tsx    # React context for auth state & methods
-│   ├── authClient.ts       # API client with remote + local fallback
-│   └── authStorage.ts      # Session persistence via expo-secure-store
-└── docs/
-    └── MOBILE_AUTH_SETUP.md  # This file
+pnpm test
 ```
 
 ## Troubleshooting
 
-### Session not persisting between launches
-- Ensure `expo-secure-store` is available on the device/simulator
-- Web browsers don't support SecureStore — use `authStorage.ts` with AsyncStorage fallback
+| Symptom | Fix |
+|---------|-----|
+| Session not persisting | Verify SecureStore availability on device |
+| Always local mock | Set `EXPO_PUBLIC_API_BASE_URL` |
+| Signed out after 15m | Ensure refresh token stored; check API refresh endpoint |
 
-### "Sign in" button does nothing
-- Check that `process.env.EXPO_PUBLIC_API_BASE_URL` is set correctly when using a real API
-- If not set, the local fallback always succeeds — no server needed
+## Open questions
 
-### Navigation broken after login
-- Verify `router.replace("/")` fires (Expo Router issue: use `replace` not `push` to avoid back-stack issues)
-- Ensure `signIn()` resolves before calling `router.replace()`
-
-### AuthClientError: "Invalid response payload"
-- The API returned a successful envelope (`{ success: true }`) but the data shape didn't match `SignupResponseData` / `LoginResponseData`
-- Verify the backend returns `{ success: true, data: { token, user, session } }`
-
-### AuthClientError: "Unknown response envelope"
-- The API returned a non-standard JSON structure
-- Check that the response is wrapped in `{ success: true/false, data/code/message }` format
+- Protected stack navigator not yet enforced — home screen reflects session state
+- Web SecureStore fallback not implemented — use device/simulator for session tests

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -7,6 +7,7 @@
     "build": "node -e \"console.log('Use EAS or expo export when mobile release work begins.')\"",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf .expo dist expo-dist"
   },
   "dependencies": {

--- a/apps/mobile/src/auth/AuthProvider.tsx
+++ b/apps/mobile/src/auth/AuthProvider.tsx
@@ -2,8 +2,9 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useS
 
 import type { AuthSession, LoginRequest, SignupRequest } from "@themixmatch/types";
 
-import { AuthClientError, login as loginClient, register } from "./authClient";
+import { AuthClientError, login as loginClient, logoutSession, register } from "./authClient";
 import { clearAuthSession, loadAuthSession, saveAuthSession } from "./authStorage";
+import { ensureSessionContinuity } from "./sessionContinuity";
 
 type AuthStatus = "loading" | "signedOut" | "signedIn";
 
@@ -31,17 +32,38 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     let mounted = true;
-    loadAuthSession()
-      .then((stored) => {
+
+    async function bootstrap() {
+      try {
+        const stored = await loadAuthSession();
         if (!mounted) return;
-        if (stored) { setSession(stored); setStatus("signedIn"); return; }
-        setStatus("signedOut");
-      })
-      .catch((error) => {
+
+        if (!stored) {
+          setStatus("signedOut");
+          return;
+        }
+
+        const outcome = await ensureSessionContinuity(stored);
+        if (!mounted) return;
+
+        if (outcome.status === "expired") {
+          await clearAuthSession();
+          setSession(null);
+          setStatus("signedOut");
+          return;
+        }
+
+        await saveAuthSession(outcome.session);
+        setSession(outcome.session);
+        setStatus("signedIn");
+      } catch (error) {
         if (!mounted) return;
         setLastError(error instanceof AuthClientError ? error : new AuthClientError("invalid_response", "Failed to load session", { details: error }));
         setStatus("signedOut");
-      });
+      }
+    }
+
+    void bootstrap();
     return () => { mounted = false; };
   }, []);
 
@@ -63,10 +85,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signOut = useCallback(async () => {
     setLastError(null);
+    const refreshToken = session?.refreshToken;
     await clearAuthSession();
     setSession(null);
     setStatus("signedOut");
-  }, []);
+    if (refreshToken) {
+      try {
+        await logoutSession(refreshToken);
+      } catch {
+        // Local session is already cleared — server revocation is best-effort
+      }
+    }
+  }, [session?.refreshToken]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/apps/mobile/src/auth/__tests__/sessionContinuity.test.ts
+++ b/apps/mobile/src/auth/__tests__/sessionContinuity.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UserRole } from "@themixmatch/types";
+import type { AuthSession } from "@themixmatch/types";
+
+import { ensureSessionContinuity, evaluateProtectedRouteGuard } from "../sessionContinuity";
+
+const mockIntrospectSession = vi.fn();
+const mockRefreshSession = vi.fn();
+
+vi.mock("../authClient", () => ({
+  introspectSession: (...args: unknown[]) => mockIntrospectSession(...args),
+  refreshSession: (...args: unknown[]) => mockRefreshSession(...args),
+}));
+
+const storedSession: AuthSession = {
+  token: "access.token",
+  refreshToken: "refresh.token",
+  user: {
+    id: "user-1",
+    name: "dj",
+    email: "dj@example.com",
+    role: UserRole.DJ,
+    onboardingCompleted: false,
+  },
+  session: {
+    userId: "user-1",
+    role: UserRole.DJ,
+    onboardingCompleted: false,
+    issuedAt: "2026-06-01T12:00:00.000Z",
+    wallet: {
+      service: "stellar-service",
+      status: "unlinked",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      horizonUrl: "https://horizon-testnet.stellar.org",
+      availableWallets: ["phantom", "freighter"],
+    },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ensureSessionContinuity (mobile)", () => {
+  it("returns valid when introspection succeeds", async () => {
+    mockIntrospectSession.mockResolvedValue({ valid: true });
+
+    await expect(ensureSessionContinuity(storedSession)).resolves.toEqual({
+      status: "valid",
+      session: storedSession,
+    });
+  });
+
+  it("returns expired when refresh fails", async () => {
+    mockIntrospectSession.mockResolvedValue({ valid: false });
+    mockRefreshSession.mockRejectedValue(new Error("refresh failed"));
+
+    await expect(ensureSessionContinuity(storedSession)).resolves.toEqual({ status: "expired" });
+  });
+});
+
+describe("evaluateProtectedRouteGuard (mobile)", () => {
+  it("denies access when no session is present", () => {
+    expect(evaluateProtectedRouteGuard(null)).toEqual({
+      allowed: false,
+      reason: "missing_session",
+    });
+  });
+});

--- a/apps/mobile/src/auth/authClient.ts
+++ b/apps/mobile/src/auth/authClient.ts
@@ -1,4 +1,13 @@
-import type { ApiError, AuthSession, LoginRequest, SignupRequest, SignupResponseData } from "@themixmatch/types";
+import type {
+  ApiError,
+  AuthSession,
+  IntrospectResponse,
+  LoginRequest,
+  SessionLogoutResponse,
+  SessionRefreshResponse,
+  SignupRequest,
+  SignupResponseData,
+} from "@themixmatch/types";
 import { UserRole } from "@themixmatch/types";
 
 export type AuthClientErrorKind = "network" | "http" | "api" | "invalid_response";
@@ -34,6 +43,21 @@ const isSignupData = (value: unknown): value is SignupResponseData => {
   return true;
 };
 
+const isSessionRefreshData = (value: unknown): value is SessionRefreshResponse => {
+  if (!isRecord(value)) return false;
+  return typeof value.accessToken === "string" && typeof value.refreshToken === "string" && typeof value.expiresAt === "string";
+};
+
+const isIntrospectData = (value: unknown): value is IntrospectResponse => {
+  if (!isRecord(value)) return false;
+  return typeof value.valid === "boolean";
+};
+
+const isLogoutData = (value: unknown): value is SessionLogoutResponse => {
+  if (!isRecord(value)) return false;
+  return typeof value.loggedOut === "boolean";
+};
+
 const parseEnvelope = (value: unknown): SignupResponseData => {
   if (!isRecord(value)) throw new AuthClientError("invalid_response", "Invalid response shape");
   if (isApiSuccess(value)) {
@@ -53,10 +77,29 @@ const apiEndpoint = (path: string) => `${(apiBaseUrl ?? "http://localhost:3001")
 const randomId = () => `user_${Math.random().toString(16).slice(2)}_${Date.now().toString(16)}`;
 const sessionFromSignup = (data: SignupResponseData): AuthSession => data;
 
-async function remoteFetch<T>(url: string, body: unknown, parseData: (json: unknown) => T): Promise<T> {
+interface RequestOptions {
+  method?: string;
+  authorization?: string;
+}
+
+async function remoteFetch<T>(
+  url: string,
+  body: unknown,
+  parseData: (json: unknown) => T,
+  options?: RequestOptions,
+): Promise<T> {
   let response: Response;
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (options?.authorization) {
+    headers.authorization = options.authorization;
+  }
+
   try {
-    response = await fetch(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    response = await fetch(url, {
+      method: options?.method ?? "POST",
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
   } catch (error) {
     throw new AuthClientError("network", error instanceof Error ? error.message : "Network error");
   }
@@ -83,13 +126,22 @@ async function loginRemote(input: LoginRequest): Promise<AuthSession> {
 // Local-only helpers (offline / no API base URL)
 // ---------------------------------------------------------------------------
 
+const defaultWallet = {
+  service: "stellar-service" as const,
+  status: "unlinked" as const,
+  networkPassphrase: "Test SDF Network ; September 2015",
+  horizonUrl: "https://horizon-testnet.stellar.org",
+  availableWallets: ["phantom", "freighter"],
+};
+
 async function registerLocal(input: SignupRequest): Promise<AuthSession> {
   const userId = randomId();
   const now = new Date().toISOString();
   return {
     token: `local.${userId}.${Date.now()}`,
+    refreshToken: `local.refresh.${userId}.${Date.now()}`,
     user: { id: userId, name: input.email.split("@")[0]?.trim() || "mixmatch-user", email: input.email.toLowerCase(), role: input.role, onboardingCompleted: false, createdAt: now, updatedAt: now },
-    session: { userId, role: input.role ?? UserRole.MUSIC_LOVER, onboardingCompleted: false, issuedAt: now },
+    session: { userId, role: input.role ?? UserRole.MUSIC_LOVER, onboardingCompleted: false, issuedAt: now, wallet: defaultWallet },
   };
 }
 
@@ -98,27 +150,22 @@ async function loginLocal(input: LoginRequest): Promise<AuthSession> {
   const now = new Date().toISOString();
   return {
     token: `local.${userId}.${Date.now()}`,
+    refreshToken: `local.refresh.${userId}.${Date.now()}`,
     user: {
       id: userId,
       name: input.email.split("@")[0]?.trim() || "mixmatch-user",
       email: input.email.toLowerCase(),
-      role: input.role,
+      role: UserRole.MUSIC_LOVER,
       onboardingCompleted: false,
       createdAt: now,
       updatedAt: now,
     },
     session: {
       userId,
-      role: input.role ?? UserRole.MUSIC_LOVER,
+      role: UserRole.MUSIC_LOVER,
       onboardingCompleted: false,
       issuedAt: now,
-      wallet: {
-        service: "stellar-service",
-        status: "unlinked",
-        networkPassphrase: "Test SDF Network ; September 2015",
-        horizonUrl: "https://horizon-testnet.stellar.org",
-        availableWallets: ["phantom", "freighter"],
-      },
+      wallet: defaultWallet,
     },
   };
 }
@@ -133,4 +180,67 @@ export async function register(input: SignupRequest): Promise<AuthSession> {
 
 export async function login(input: LoginRequest): Promise<AuthSession> {
   return apiBaseUrl ? loginRemote(input) : loginLocal(input);
+}
+
+export async function refreshSession(refreshToken: string): Promise<SessionRefreshResponse> {
+  if (!apiBaseUrl) {
+    return {
+      accessToken: `local.${Date.now()}`,
+      refreshToken: `local.refresh.${Date.now()}`,
+      expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    };
+  }
+
+  return remoteFetch(
+    apiEndpoint("/api/v1/auth/refresh"),
+    { refreshToken },
+    (json) => {
+      if (isApiSuccess(json) && isSessionRefreshData(json.data)) {
+        return json.data;
+      }
+      throw new AuthClientError("invalid_response", "Invalid refresh payload");
+    },
+  );
+}
+
+export async function introspectSession(accessToken: string): Promise<IntrospectResponse> {
+  if (!apiBaseUrl) {
+    return accessToken.startsWith("local.") ? { valid: true } : { valid: false };
+  }
+
+  try {
+    return await remoteFetch(
+      apiEndpoint("/api/v1/auth/introspect"),
+      null,
+      (json) => {
+        if (isApiSuccess(json) && isIntrospectData(json.data)) {
+          return json.data;
+        }
+        throw new AuthClientError("invalid_response", "Invalid introspection payload");
+      },
+      { method: "GET", authorization: `Bearer ${accessToken}` },
+    );
+  } catch (error) {
+    if (error instanceof AuthClientError && error.status === 401) {
+      return { valid: false };
+    }
+    throw error;
+  }
+}
+
+export async function logoutSession(refreshToken: string): Promise<SessionLogoutResponse> {
+  if (!apiBaseUrl) {
+    return { loggedOut: true };
+  }
+
+  return remoteFetch(
+    apiEndpoint("/api/v1/auth/logout"),
+    { refreshToken },
+    (json) => {
+      if (isApiSuccess(json) && isLogoutData(json.data)) {
+        return json.data;
+      }
+      throw new AuthClientError("invalid_response", "Invalid logout payload");
+    },
+  );
 }

--- a/apps/mobile/src/auth/sessionContinuity.ts
+++ b/apps/mobile/src/auth/sessionContinuity.ts
@@ -1,0 +1,46 @@
+import type { AuthSession, ProtectedRouteGuard, SessionContinuityOutcome } from "@themixmatch/types";
+
+import { introspectSession, refreshSession } from "./authClient";
+
+export async function ensureSessionContinuity(
+  stored: AuthSession,
+): Promise<SessionContinuityOutcome> {
+  const introspection = await introspectSession(stored.token);
+  if (introspection.valid) {
+    return { status: "valid", session: stored };
+  }
+
+  if (!stored.refreshToken) {
+    return { status: "expired" };
+  }
+
+  try {
+    const refreshed = await refreshSession(stored.refreshToken);
+    const nextSession: AuthSession = {
+      ...stored,
+      token: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      session: {
+        ...stored.session,
+        issuedAt: new Date().toISOString(),
+      },
+    };
+    return { status: "refreshed", session: nextSession };
+  } catch {
+    return { status: "expired" };
+  }
+}
+
+export function evaluateProtectedRouteGuard(
+  session: AuthSession | null,
+): ProtectedRouteGuard {
+  if (!session?.token) {
+    return { allowed: false, reason: "missing_session" };
+  }
+
+  return {
+    allowed: true,
+    userId: session.user.id,
+    role: session.user.role,
+  };
+}

--- a/apps/stellar-service/docs/STELLAR_AUTH_BOUNDARY.md
+++ b/apps/stellar-service/docs/STELLAR_AUTH_BOUNDARY.md
@@ -1,0 +1,42 @@
+# Stellar Service — Auth Boundary
+
+## Overview
+
+The Stellar service provides the auth-to-Stellar handoff: wallet challenge generation and session verification. Shared request/response types live in `@themixmatch/types`.
+
+The API proxies these routes at `/api/v1/stellar/auth/*` using `STELLAR_SERVICE_URL`.
+
+## Routes
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/handshake` | Network + wallet metadata |
+| POST | `/api/v1/stellar/auth/challenge` | Generate challenge transaction XDR |
+| POST | `/api/v1/stellar/auth/verify` | Verify session token + Stellar public key |
+
+## Shared contracts
+
+| Type | Purpose |
+|------|---------|
+| `StellarServiceHandshake` | Handshake metadata |
+| `StellarAuthChallengeRequest/Response` | Challenge flow |
+| `StellarAuthVerifyRequest/Response` | Verify flow |
+
+## Environment
+
+| Variable | Default |
+|----------|---------|
+| `STELLAR_SERVICE_PORT` | 3002 |
+| `STELLAR_NETWORK_PASSPHRASE` | Testnet |
+| `STELLAR_HORIZON_URL` | https://horizon-testnet.stellar.org |
+
+## Extension points
+
+- Challenge verify currently checks token format and key shape only
+- On-chain signature validation is a follow-up milestone
+- Wallet linking status flows through `SessionBootstrap.wallet` on login/register
+
+## Related docs
+
+- [Session Lifecycle](../../docs/SESSION_LIFECYCLE.md)
+- [Monorepo Auth Setup](../../docs/MONOREPO_AUTH_SETUP.md)

--- a/apps/stellar-service/src/index.ts
+++ b/apps/stellar-service/src/index.ts
@@ -3,7 +3,12 @@ import dotenv from "dotenv";
 import express, { type Request, type Response } from "express";
 import { z } from "zod";
 
-import type { StellarHealthResponse, StellarServiceHandshake } from "@themixmatch/types";
+import type {
+  StellarHealthResponse,
+  StellarServiceHandshake,
+  StellarAuthChallengeResponse,
+  StellarAuthVerifyResponse,
+} from "@themixmatch/types";
 
 dotenv.config();
 
@@ -94,7 +99,7 @@ app.post("/api/v1/stellar/auth/challenge", (req: Request, res: Response) => {
       transactionXdr: tx.toXDR(),
       networkPassphrase: env.STELLAR_NETWORK_PASSPHRASE,
       expiresAt,
-    },
+    } satisfies StellarAuthChallengeResponse,
   });
 });
 
@@ -135,7 +140,7 @@ app.post("/api/v1/stellar/auth/verify", (req: Request, res: Response) => {
       verified: true,
       stellarAccountId,
       linkedAt: new Date().toISOString(),
-    },
+    } satisfies StellarAuthVerifyResponse,
   });
 });
 

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -3,18 +3,21 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/auth/auth-context";
+import { evaluateProtectedRouteGuard } from "@/auth/session-continuity";
 
 export default function DashboardPage() {
   const router = useRouter();
-  const { user, session, isAuthenticated, signOut } = useAuth();
+  const { user, session, isAuthenticated, isBootstrapping, signOut } = useAuth();
+  const guard = evaluateProtectedRouteGuard(session);
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (isBootstrapping) return;
+    if (!guard.allowed) {
       router.replace("/login");
     }
-  }, [isAuthenticated, router]);
+  }, [guard.allowed, isBootstrapping, router]);
 
-  if (!isAuthenticated) {
+  if (isBootstrapping || !isAuthenticated || !guard.allowed) {
     return (
       <main className="page-shell">
         <section className="hero-card">

--- a/apps/web/auth/auth-client.ts
+++ b/apps/web/auth/auth-client.ts
@@ -1,4 +1,12 @@
-import type { ApiError, AuthSession, LoginRequest, SignupRequest } from "@themixmatch/types";
+import type {
+  ApiError,
+  AuthSession,
+  IntrospectResponse,
+  LoginRequest,
+  SessionLogoutResponse,
+  SessionRefreshResponse,
+  SignupRequest,
+} from "@themixmatch/types";
 
 type AuthClientErrorKind = "network" | "http" | "api" | "invalid_response";
 
@@ -37,17 +45,27 @@ const apiBaseUrl =
   (typeof process !== "undefined" && process.env?.NEXT_PUBLIC_API_BASE_URL) ||
   "http://localhost:3001";
 
+interface RequestOptions {
+  authorization?: string;
+}
+
 async function request<T>(
   method: string,
   path: string,
   body: unknown,
   parseEnvelope: (json: unknown) => T,
+  options?: RequestOptions,
 ): Promise<T> {
   let response: Response;
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (options?.authorization) {
+    headers.authorization = options.authorization;
+  }
+
   try {
     response = await fetch(`${apiBaseUrl.replace(/\/$/, "")}${path}`, {
       method,
-      headers: { "content-type": "application/json" },
+      headers,
       body: body ? JSON.stringify(body) : undefined,
     });
   } catch (error) {
@@ -97,6 +115,46 @@ export async function register(input: SignupRequest): Promise<AuthSession> {
 export async function login(input: LoginRequest): Promise<AuthSession> {
   return request("POST", "/api/v1/auth/login", input, (json) => {
     if (isApiSuccess<AuthSession>(json)) return json.data;
+    if (isApiError(json))
+      throw new AuthClientError("api", json.message, { code: json.code });
+    throw new AuthClientError("invalid_response", "Unknown envelope");
+  });
+}
+
+export async function refreshSession(refreshToken: string): Promise<SessionRefreshResponse> {
+  return request("POST", "/api/v1/auth/refresh", { refreshToken }, (json) => {
+    if (isApiSuccess<SessionRefreshResponse>(json)) return json.data;
+    if (isApiError(json))
+      throw new AuthClientError("api", json.message, { code: json.code });
+    throw new AuthClientError("invalid_response", "Unknown envelope");
+  });
+}
+
+export async function introspectSession(accessToken: string): Promise<IntrospectResponse> {
+  try {
+    return await request(
+      "GET",
+      "/api/v1/auth/introspect",
+      null,
+      (json) => {
+        if (isApiSuccess<IntrospectResponse>(json)) return json.data;
+        if (isApiError(json))
+          throw new AuthClientError("api", json.message, { code: json.code });
+        throw new AuthClientError("invalid_response", "Unknown envelope");
+      },
+      { authorization: `Bearer ${accessToken}` },
+    );
+  } catch (error) {
+    if (error instanceof AuthClientError && error.status === 401) {
+      return { valid: false };
+    }
+    throw error;
+  }
+}
+
+export async function logoutSession(refreshToken: string): Promise<SessionLogoutResponse> {
+  return request("POST", "/api/v1/auth/logout", { refreshToken }, (json) => {
+    if (isApiSuccess<SessionLogoutResponse>(json)) return json.data;
     if (isApiError(json))
       throw new AuthClientError("api", json.message, { code: json.code });
     throw new AuthClientError("invalid_response", "Unknown envelope");

--- a/apps/web/auth/auth-context.tsx
+++ b/apps/web/auth/auth-context.tsx
@@ -11,12 +11,14 @@ import {
 import type { ReactNode } from "react";
 import type { AuthSession } from "@themixmatch/types";
 import { authStorage } from "./auth-storage";
-import { isSessionExpired } from "./auth-session";
+import { logoutSession } from "./auth-client";
+import { ensureSessionContinuity } from "./session-continuity";
 
 interface AuthContextValue {
   session: AuthSession | null;
   user: AuthSession["user"] | null;
   isAuthenticated: boolean;
+  isBootstrapping: boolean;
   signIn(session: AuthSession): void;
   signOut(): void;
 }
@@ -31,16 +33,39 @@ export function AuthProvider({
   children: ReactNode;
 }) {
   const [session, setSession] = useState<AuthSession | null>(null);
+  const [isBootstrapping, setIsBootstrapping] = useState(true);
 
   useEffect(() => {
-    const stored = authStorage.loadSession();
-    if (stored && !isSessionExpired(stored)) {
-      setSession(stored);
-      return;
+    let mounted = true;
+
+    async function bootstrap() {
+      const stored = authStorage.loadSession();
+      if (!stored) {
+        if (mounted) {
+          setSession(null);
+          setIsBootstrapping(false);
+        }
+        return;
+      }
+
+      const outcome = await ensureSessionContinuity(stored);
+      if (!mounted) return;
+
+      if (outcome.status === "expired") {
+        authStorage.clearSession();
+        setSession(null);
+      } else {
+        authStorage.saveSession(outcome.session);
+        setSession(outcome.session);
+      }
+
+      setIsBootstrapping(false);
     }
 
-    authStorage.clearSession();
-    setSession(null);
+    void bootstrap();
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   const signIn = useCallback((authSession: AuthSession) => {
@@ -49,19 +74,24 @@ export function AuthProvider({
   }, []);
 
   const signOut = useCallback(() => {
+    const refreshToken = session?.refreshToken;
     authStorage.clearSession();
     setSession(null);
-  }, []);
+    if (refreshToken) {
+      void logoutSession(refreshToken).catch(() => undefined);
+    }
+  }, [session?.refreshToken]);
 
   const value = useMemo(
     () => ({
       session,
       user: session?.user ?? null,
       isAuthenticated: Boolean(session),
+      isBootstrapping,
       signIn,
       signOut,
     }),
-    [session, signIn, signOut],
+    [session, isBootstrapping, signIn, signOut],
   );
 
   return (

--- a/apps/web/auth/auth-storage.ts
+++ b/apps/web/auth/auth-storage.ts
@@ -2,50 +2,34 @@ import type { AuthSession } from "@themixmatch/types";
 
 const STORAGE_KEY = "mixmatch:auth-session";
 
-export async function loadAuthSession(): Promise<AuthSession | null> {
-  if (typeof window === "undefined") return null;
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw) as AuthSession;
-  } catch {
-    localStorage.removeItem(STORAGE_KEY);
-    return null;
-  }
+function isValidSession(value: unknown): value is AuthSession {
+  if (typeof value !== "object" || value === null) return false;
+  const parsed = value as AuthSession;
+  return Boolean(parsed.token && parsed.user && parsed.session);
 }
 
-export async function saveAuthSession(session: AuthSession): Promise<void> {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
-}
-
-    if (!raw) {
-      return null;
-    }
+export const authStorage = {
+  loadSession(): AuthSession | null {
+    if (typeof window === "undefined") return null;
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
 
     try {
-      const parsed = JSON.parse(raw) as AuthSession;
-      if (
-        !parsed?.token ||
-        !parsed?.user ||
-        !parsed?.session
-      ) {
-        return null;
-      }
-      return parsed;
+      const parsed: unknown = JSON.parse(raw);
+      return isValidSession(parsed) ? parsed : null;
     } catch {
+      localStorage.removeItem(STORAGE_KEY);
       return null;
     }
   },
 
-  clearSession() {
-    localStorage.removeItem(
-      SESSION_STORAGE_KEY,
-    );
-  },
+  saveSession(session: AuthSession): void {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
   },
 
   clearSession(): void {
-    localStorage.removeItem(SESSION_KEY);
+    if (typeof window === "undefined") return;
+    localStorage.removeItem(STORAGE_KEY);
   },
 };

--- a/apps/web/auth/session-continuity.test.ts
+++ b/apps/web/auth/session-continuity.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UserRole } from "@themixmatch/types";
+import type { AuthSession } from "@themixmatch/types";
+
+const { mockIntrospectSession, mockRefreshSession } = vi.hoisted(() => ({
+  mockIntrospectSession: vi.fn(),
+  mockRefreshSession: vi.fn(),
+}));
+
+vi.mock("./auth-client", () => ({
+  introspectSession: (...args: unknown[]) => mockIntrospectSession(...args),
+  refreshSession: (...args: unknown[]) => mockRefreshSession(...args),
+}));
+
+import { ensureSessionContinuity, evaluateProtectedRouteGuard } from "./session-continuity";
+
+const storedSession: AuthSession = {
+  token: "access.token",
+  refreshToken: "refresh.token",
+  user: {
+    id: "user-1",
+    name: "dj",
+    email: "dj@example.com",
+    role: UserRole.DJ,
+    onboardingCompleted: false,
+  },
+  session: {
+    userId: "user-1",
+    role: UserRole.DJ,
+    onboardingCompleted: false,
+    issuedAt: "2026-06-01T12:00:00.000Z",
+    wallet: {
+      service: "stellar-service",
+      status: "unlinked",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      horizonUrl: "https://horizon-testnet.stellar.org",
+      availableWallets: ["phantom", "freighter"],
+    },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ensureSessionContinuity", () => {
+  it("returns valid when introspection succeeds", async () => {
+    mockIntrospectSession.mockResolvedValue({ valid: true, userId: "user-1", role: UserRole.DJ });
+
+    await expect(ensureSessionContinuity(storedSession)).resolves.toEqual({
+      status: "valid",
+      session: storedSession,
+    });
+  });
+
+  it("refreshes the session when introspection fails but refresh succeeds", async () => {
+    mockIntrospectSession.mockResolvedValue({ valid: false });
+    mockRefreshSession.mockResolvedValue({
+      accessToken: "new.access.token",
+      refreshToken: "new.refresh.token",
+      expiresAt: "2026-06-01T12:15:00.000Z",
+    });
+
+    const outcome = await ensureSessionContinuity(storedSession);
+
+    expect(outcome.status).toBe("refreshed");
+    if (outcome.status === "refreshed") {
+      expect(outcome.session.token).toBe("new.access.token");
+      expect(outcome.session.refreshToken).toBe("new.refresh.token");
+    }
+  });
+
+  it("returns expired when refresh is unavailable", async () => {
+    mockIntrospectSession.mockResolvedValue({ valid: false });
+    mockRefreshSession.mockRejectedValue(new Error("refresh failed"));
+
+    await expect(ensureSessionContinuity(storedSession)).resolves.toEqual({ status: "expired" });
+  });
+});
+
+describe("evaluateProtectedRouteGuard", () => {
+  it("denies access when no session is present", () => {
+    expect(evaluateProtectedRouteGuard(null)).toEqual({
+      allowed: false,
+      reason: "missing_session",
+    });
+  });
+
+  it("allows access when a session token is present", () => {
+    expect(evaluateProtectedRouteGuard(storedSession)).toEqual({
+      allowed: true,
+      userId: "user-1",
+      role: UserRole.DJ,
+    });
+  });
+});

--- a/apps/web/auth/session-continuity.ts
+++ b/apps/web/auth/session-continuity.ts
@@ -1,0 +1,51 @@
+import type { AuthSession, ProtectedRouteGuard, SessionContinuityOutcome } from "@themixmatch/types";
+
+import { introspectSession, refreshSession } from "./auth-client";
+
+/**
+ * Shared session seam — validates a stored session and refreshes when needed.
+ * Web and mobile clients follow the same contract-driven flow.
+ */
+export async function ensureSessionContinuity(
+  stored: AuthSession,
+): Promise<SessionContinuityOutcome> {
+  const introspection = await introspectSession(stored.token);
+  if (introspection.valid) {
+    return { status: "valid", session: stored };
+  }
+
+  if (!stored.refreshToken) {
+    return { status: "expired" };
+  }
+
+  try {
+    const refreshed = await refreshSession(stored.refreshToken);
+    const nextSession: AuthSession = {
+      ...stored,
+      token: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      session: {
+        ...stored.session,
+        issuedAt: new Date().toISOString(),
+      },
+    };
+    return { status: "refreshed", session: nextSession };
+  } catch {
+    return { status: "expired" };
+  }
+}
+
+/** Maps a stored session to the shared protected-route guard contract. */
+export function evaluateProtectedRouteGuard(
+  session: AuthSession | null,
+): ProtectedRouteGuard {
+  if (!session?.token) {
+    return { allowed: false, reason: "missing_session" };
+  }
+
+  return {
+    allowed: true,
+    userId: session.user.id,
+    role: session.user.role,
+  };
+}

--- a/apps/web/docs/WEB_AUTH_SETUP.md
+++ b/apps/web/docs/WEB_AUTH_SETUP.md
@@ -1,83 +1,68 @@
-# Web Auth Surface — Sign-In Setup & Troubleshooting
+# Web Auth Surface — Setup & Troubleshooting
 
 ## Overview
 
-The web authentication surface handles credential-based sign-in via a Next.js frontend and an Express API backend. The flow follows a shared contract defined in `packages/types/src/auth.ts` and is designed to be extended for wallet-aware identity without premature coupling.
+The web app uses shared auth contracts from `@themixmatch/types` and the same session continuity seam as mobile. Protected routes evaluate the shared `ProtectedRouteGuard` contract rather than ad-hoc checks.
+
+See [Session Lifecycle](../../../docs/SESSION_LIFECYCLE.md) for the full lifecycle guide.
 
 ## Contracts & Routes
 
 | Contract | Location |
-|---|---|
-| Login types (LoginRequest, LoginResponseData, CredentialErrorCode) | `packages/types/src/auth.ts` |
-| API envelope types (ApiSuccess, ApiError, ApiEnvelope) | `packages/types/src/auth.ts` |
+|----------|----------|
+| Session types | `packages/types/src/auth.ts` |
+| Guard contract | `packages/types/src/session.types.ts` |
+| Session continuity | `apps/web/auth/session-continuity.ts` |
 
-### API Endpoint
+### API endpoints used by web client
 
-```
-POST /api/v1/auth/login
-```
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/v1/auth/register` | Registration |
+| POST | `/api/v1/auth/login` | Sign in |
+| POST | `/api/v1/auth/refresh` | Rotate token pair |
+| GET | `/api/v1/auth/introspect` | Validate access token |
+| POST | `/api/v1/auth/logout` | Revoke refresh token |
 
-- **Body**: `{ email: string, password: string }`
-- **Success (200)**: `{ success: true, data: { token, user, session } }`
-- **Error (401)**: `{ success: false, code: "AUTH_INVALID_CREDENTIALS", message: "Invalid email or password" }`
-- **Error (422)**: `{ success: false, code: "VALIDATION_INVALID_INPUT", message: "Validation failed for body" }`
-
-## Environment Values
+## Environment
 
 | Variable | Default | Required |
-|---|---|---|
-| `NEXT_PUBLIC_API_URL` | `http://localhost:3001/api/v1` | No |
-| `API_PORT` (API) | `3001` | No |
+|----------|---------|----------|
+| `NEXT_PUBLIC_API_BASE_URL` | `http://localhost:3001` | No |
 
-## Running the Flow
-
-### Prerequisites
-
-1.  API server running on port 3001:
-    ```bash
-    cd apps/api
-    pnpm dev
-    ```
-2.  Web dev server running on port 3000:
-    ```bash
-    cd apps/web
-    pnpm dev
-    ```
-
-### Exercise the Flow
-
-1.  Navigate to `http://localhost:3000/signup`
-2.  Create an account with email, password, and role
-3.  Navigate to `http://localhost:3000/login`
-4.  Sign in with the credentials from step 2
-5.  On success you are redirected to `/` with the session persisted in localStorage
-
-## Key Files
+## Key files
 
 | File | Purpose |
-|---|---|
-| `apps/web/app/login/page.tsx` | Login page UI with form, loading, error states |
-| `apps/web/app/hooks/useLogin.ts` | Login hook for credential submission and redirect |
-| `apps/web/auth/auth-client.ts` | Auth API client (signup + login) |
-| `apps/web/auth/auth-store.ts` | Zustand store for auth state |
-| `apps/web/auth/auth-storage.ts` | localStorage persistence for session |
-| `apps/api/src/domains/identity/login.handler.ts` | API login request handler |
-| `apps/api/src/domains/identity/login.service.ts` | Credential validation & session issuance |
-| `apps/api/src/domains/identity/login.validation.ts` | Zod schema for login payload |
-| `apps/api/src/domains/identity/login.service.test.ts` | Regression tests |
+|------|---------|
+| `auth/auth-client.ts` | HTTP client (register, login, refresh, introspect, logout) |
+| `auth/auth-storage.ts` | localStorage persistence |
+| `auth/auth-context.tsx` | AuthProvider with session continuity bootstrap |
+| `auth/session-continuity.ts` | `ensureSessionContinuity`, `evaluateProtectedRouteGuard` |
+| `app/dashboard/page.tsx` | Protected route example |
+
+## Exercise the flow
+
+1. Start API: `cd apps/api && pnpm dev`
+2. Start web: `cd apps/web && pnpm dev`
+3. Register at `/signup`, sign in at `/login`
+4. Visit `/dashboard` — requires active session
+5. Sign out — clears storage and revokes refresh token
+
+## Run tests
+
+```bash
+pnpm test
+```
 
 ## Troubleshooting
 
-| Symptom | Likely Cause | Fix |
-|---|---|---|
-| `401` on login | Wrong email or password | Verify credentials or re-register |
-| `422` on login | Missing or invalid fields | Ensure email format and non-empty password |
-| `CORS` error in browser | API not running or wrong port | Start API on port 3001 or update `NEXT_PUBLIC_API_URL` |
-| `Cannot fetch` | API server not running | Start API: `cd apps/api && pnpm dev` |
-| Session not persisted | localStorage cleared or blocked | Check browser storage settings |
+| Symptom | Fix |
+|---------|-----|
+| Redirect to login after reload | Check refresh token in stored session; verify API `/auth/refresh` |
+| `Cannot fetch` | Start API on port 3001 |
+| Dashboard stuck on loading | Wait for `isBootstrapping` to finish in AuthProvider |
 
-## Open Questions & Trade-offs
+## Open questions
 
-- **Token storage**: Currently stored in localStorage. A production version should use httpOnly cookies for XSS protection.
-- **Token refresh**: No refresh token rotation is implemented. Sessions are valid for 7 days via JWT expiry.
-- **Wallet-aware identity**: The `LoginRequest` / `AuthResponse` contracts are designed so that a wallet address field can be added without breaking existing credential auth.
+- Token storage is localStorage — production should use httpOnly cookies
+- No Next.js middleware yet — guards are client-side via shared contract

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "start": "next start --port 3000",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit",
+    "test": "vitest run",
     "clean": "rm -rf .next"
   },
   "dependencies": {
@@ -20,6 +21,7 @@
   "devDependencies": {
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.12",
-    "@types/react-dom": "^19.1.9"
+    "@types/react-dom": "^19.1.9",
+    "vitest": "^4.1.7"
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["**/*.test.ts", "**/*.test.tsx"],
+  },
+});

--- a/docs/MONOREPO_AUTH_SETUP.md
+++ b/docs/MONOREPO_AUTH_SETUP.md
@@ -2,113 +2,115 @@
 
 ## Overview
 
-The MixMatch Onchain monorepo implements a three-tier authentication system:
+The MixMatch Onchain monorepo implements authentication across four workspaces with shared contracts in `@themixmatch/types`:
 
-1. **API service** (`apps/api`) — Express server handling credential validation and session issuance
-2. **Web app** (`apps/web`) — Next.js frontend with login/register flows
-3. **Mobile app** (`apps/mobile`) — Expo React Native frontend
-4. **Stellar service** (`apps/stellar-service`) — Stellar network boundary for on-chain operations
+1. **API service** (`apps/api`) — session issuance, refresh, introspection, logout, route guards
+2. **Web app** (`apps/web`) — Next.js client with session continuity and protected routes
+3. **Mobile app** (`apps/mobile`) — Expo client with the same session seam
+4. **Stellar service** (`apps/stellar-service`) — wallet challenge/verify boundary
+
+See [Session Lifecycle](./SESSION_LIFECYCLE.md) for the full contributor guide.
 
 ## Shared Contracts (`packages/types`)
 
 | Type | File | Used By |
 |------|------|---------|
-| `LoginRequest` | `packages/types/src/auth.ts` | API, Web, Mobile, Stellar |
-| `LoginResponseData` | `packages/types/src/auth.ts` | API, Web, Mobile, Stellar |
-| `CredentialErrorCode` | `packages/types/src/auth.ts` | API, Web, Mobile |
-| `CredentialErrorContract` | `packages/types/src/auth.ts` | Stellar boundary |
+| `LoginRequest` / `LoginResponseData` | `packages/types/src/auth.ts` | API, Web, Mobile |
+| `SessionRefreshRequest` / `SessionRefreshResponse` | `packages/types/src/auth.ts` | API, Web, Mobile |
+| `IntrospectResponse` | `packages/types/src/auth.ts` | API, Web, Mobile |
+| `SessionLogoutRequest` / `SessionLogoutResponse` | `packages/types/src/auth.ts` | API, Web, Mobile |
+| `SessionContinuityOutcome` | `packages/types/src/auth.ts` | Web, Mobile |
+| `ProtectedRouteGuard` | `packages/types/src/session.types.ts` | Web, Mobile |
+| `StellarAuthChallengeRequest/Response` | `packages/types/src/auth.ts` | API, Stellar |
+| `StellarAuthVerifyRequest/Response` | `packages/types/src/auth.ts` | API, Stellar |
 | `AuthSession` | `packages/types/src/auth.ts` | Web, Mobile |
-| `ApiEnvelope<T>` | `packages/types/src/auth.ts` | API, Web, Mobile |
-| `StellarAuthRequest` | `packages/types/src/auth.ts` | API, Stellar |
-| `StellarSessionContract` | `packages/types/src/auth.ts` | Stellar boundary |
+| `ApiSuccess` / `ApiError` | `packages/types/src/auth-envelope.types.ts` | API, Web, Mobile |
 
 ## API Routes
 
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/v1/auth/register` | Create account |
-| POST | `/api/v1/auth/login` | Sign in → token + session |
-| POST | `/api/v1/auth/refresh` | Refresh access token |
-| GET | `/api/v1/auth/introspect` | Introspect access token |
-| POST | `/api/v1/stellar/auth/challenge` | Generate Stellar challenge |
-| POST | `/api/v1/stellar/auth/verify` | Verify session on Stellar boundary |
+| POST | `/api/v1/auth/login` | Sign in → token pair + session |
+| POST | `/api/v1/auth/refresh` | Rotate refresh token |
+| GET | `/api/v1/auth/introspect` | Validate access token (protected) |
+| POST | `/api/v1/auth/logout` | Revoke refresh token |
+| GET | `/api/v1/auth/handshake` | Stellar handshake metadata |
+| POST | `/api/v1/stellar/auth/challenge` | Stellar wallet challenge |
+| POST | `/api/v1/stellar/auth/verify` | Stellar session verify |
 
 ## Web Auth Files
 
 ```
 apps/web/auth/
-├── auth-client.ts      # HTTP client for register & login (zod-free)
-├── auth-storage.ts     # localStorage persistence for AuthSession
-├── auth-session.ts     # Session expiry check (24h TTL)
+├── auth-client.ts          # register, login, refresh, introspect, logout
+├── auth-storage.ts         # localStorage persistence (sync API)
+├── auth-context.tsx        # AuthProvider with session continuity bootstrap
+├── session-continuity.ts   # shared seam: ensureSessionContinuity + guard
 apps/web/app/
-├── login/page.tsx      # Login form → auth-client → redirect
-├── hooks/useLogin.ts   # Login hook with loading/error state
-├── hooks/useSessionBootstrap.ts  # Boot session from storage
+├── login/page.tsx          # Login form
+├── dashboard/page.tsx      # Protected route (uses evaluateProtectedRouteGuard)
 ```
 
 ## Mobile Auth Files
 
 ```
 apps/mobile/src/auth/
-├── authClient.ts       # API client with remote + local fallback
-├── AuthProvider.tsx    # React context: status, session, signIn, signOut
-├── authStorage.ts       # expo-secure-store persistence
-apps/mobile/app/
-├── login.tsx           # Login screen with form
-├── _layout.tsx         # Stack navigator with login route
+├── authClient.ts           # API client with refresh/introspect/logout
+├── AuthProvider.tsx        # Session continuity on launch
+├── authStorage.ts          # expo-secure-store persistence
+├── sessionContinuity.ts    # shared seam (mirrors web)
 ```
 
 ## Stellar Auth Boundary
 
-The Stellar service provides on-chain authentication awareness at `/api/v1/stellar/auth`:
+- `GET /handshake` on stellar-service — wallet/network metadata
+- `POST /api/v1/stellar/auth/challenge` — challenge transaction XDR
+- `POST /api/v1/stellar/auth/verify` — session + Stellar key verification (stub)
 
-- `POST /api/v1/stellar/auth/verify` — Verify a session against the Stellar network
-- `POST /api/v1/stellar/auth/challenge` — Generate a Stellar challenge transaction for wallet signing
+API proxies Stellar routes using `STELLAR_SERVICE_URL`.
 
 ## Running the Full Stack
 
 ```bash
-# Terminal 1: API
-cd apps/api && pnpm dev
-
-# Terminal 2: Web (optional)
-cd apps/web && pnpm dev
-
-# Terminal 3: Mobile (optional)
-cd apps/mobile && pnpm dev
-
-# Terminal 4: Stellar service
-cd apps/stellar-service && pnpm dev
+cd apps/api && pnpm dev          # :3001
+cd apps/web && pnpm dev          # :3000
+cd apps/mobile && pnpm dev       # Expo
+cd apps/stellar-service && pnpm dev  # :3002
 ```
 
 ## Environment Variables
 
 | Variable | Required | Default | App |
 |----------|----------|---------|-----|
-| `PORT` | No | 3001 | API |
+| `JWT_SECRET` | No | dev secret | API |
+| `STELLAR_SERVICE_URL` | No | http://localhost:3002 | API |
 | `NEXT_PUBLIC_API_BASE_URL` | No | http://localhost:3001 | Web |
-| `EXPO_PUBLIC_API_BASE_URL` | No | (local mock fallback) | Mobile |
+| `EXPO_PUBLIC_API_BASE_URL` | No | (local mock) | Mobile |
 | `STELLAR_SERVICE_PORT` | No | 3002 | Stellar |
-| `STELLAR_NETWORK_PASSPHRASE` | No | Testnet | Stellar |
-| `STELLAR_HORIZON_URL` | No | https://horizon-testnet.stellar.org | Stellar |
+
+## Verification
+
+```bash
+pnpm --filter @themixmatch/api test
+pnpm --filter @themixmatch/web test
+pnpm --filter @themixmatch/mobile test
+pnpm typecheck
+```
 
 ## Troubleshooting
 
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
-| Login returns 401 | Wrong credentials | Check password; verify user exists via register |
-| "Invalid response payload" | API envelope mismatch | Ensure API returns `{ success: true, data: { token, user, session } }` |
-| Session lost on refresh | Storage key mismatch | Check localStorage key = `mixmatch:auth-session` |
-| Mobile login always succeeds | EXPO_PUBLIC_API_BASE_URL not set | The client falls back to local mock when no API URL is configured |
-| Stellar verify fails | Session not registered on-chain | Ensure wallet has signed the Stellar challenge transaction |
-| Stellar challenge fails | Invalid Stellar public key | Verify key format with Stellar SDK |
+| Session lost after 15m | Access token expired, refresh failed | Check refreshToken in stored session; verify `/auth/refresh` |
+| Dashboard redirects to login | Guard denied access | Confirm session bootstrap completed (`isBootstrapping`) |
+| Introspect returns 401 | Expired/missing Bearer token | Client should attempt refresh, then sign out |
+| Stellar proxy 502 | Stellar service not running | Start `apps/stellar-service` or set `STELLAR_SERVICE_URL` |
 
 ## PR Checklist
 
-Before opening a PR touching auth:
-- [ ] Shared types updated in `packages/types/src/auth.ts`
-- [ ] API endpoint wired in `apps/api/src/app.ts`
-- [ ] Auth client updated in relevant surface(s)
-- [ ] Login page/screen created or updated
-- [ ] Tests pass: `pnpm -r run typecheck`
-- [ ] Stellar boundary contracts updated if on-chain auth required
+- [ ] Shared types updated in `packages/types/src/`
+- [ ] API routes wired in `apps/api/src/app.ts`
+- [ ] Client auth methods updated in web/mobile
+- [ ] Session continuity tests pass
+- [ ] Docs updated in `docs/` and per-app `docs/`

--- a/docs/SESSION_LIFECYCLE.md
+++ b/docs/SESSION_LIFECYCLE.md
@@ -1,0 +1,104 @@
+# Session Lifecycle — Authentication Milestone
+
+This guide maps how protected sessions flow across the monorepo auth stack. It reflects the reset starter structure and the shared contracts in `@themixmatch/types`.
+
+## Shared contracts
+
+| Contract | Source | Purpose |
+|----------|--------|---------|
+| `SessionRefreshRequest` / `SessionRefreshResponse` | `packages/types/src/auth.ts` | Rotate access + refresh token pair |
+| `IntrospectResponse` | `packages/types/src/auth.ts` | Validate an access token without side effects |
+| `SessionLogoutRequest` / `SessionLogoutResponse` | `packages/types/src/auth.ts` | Revoke refresh token on sign-out |
+| `SessionContinuityOutcome` | `packages/types/src/auth.ts` | Client bootstrap result (`valid`, `refreshed`, `expired`) |
+| `ProtectedRouteGuard` | `packages/types/src/session.types.ts` | Shared guard vocabulary for protected routes |
+| `StellarAuthChallengeRequest/Response` | `packages/types/src/auth.ts` | Wallet challenge at auth-to-Stellar handoff |
+| `StellarAuthVerifyRequest/Response` | `packages/types/src/auth.ts` | Session verification at Stellar boundary |
+
+## API routes
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/api/v1/auth/register` | Public | Create account, issue token pair |
+| POST | `/api/v1/auth/login` | Public | Sign in, issue token pair |
+| POST | `/api/v1/auth/refresh` | Public | Rotate refresh token → new pair |
+| GET | `/api/v1/auth/introspect` | Protected | Validate access token, return claims |
+| POST | `/api/v1/auth/logout` | Public | Revoke refresh token (idempotent) |
+| GET | `/api/v1/auth/handshake` | Public | Stellar service handshake metadata |
+| POST | `/api/v1/stellar/auth/challenge` | Public | Proxy to stellar-service challenge |
+| POST | `/api/v1/stellar/auth/verify` | Public | Proxy to stellar-service verify |
+
+## Environment values
+
+| Variable | App | Default | Notes |
+|----------|-----|---------|-------|
+| `JWT_SECRET` | API | `dev-secret-key-change-in-production` | Signs access + refresh JWTs |
+| `STELLAR_SERVICE_URL` | API | `http://localhost:3002` | Stellar proxy + handshake target |
+| `NEXT_PUBLIC_API_BASE_URL` | Web | `http://localhost:3001` | Auth client base URL |
+| `EXPO_PUBLIC_API_BASE_URL` | Mobile | unset → local mock | Set to API root for remote auth |
+| `STELLAR_SERVICE_PORT` | Stellar | `3002` | Stellar service listen port |
+
+## Session lifecycle
+
+```text
+register/login
+  → store { token, refreshToken, user, session }
+  → on app boot: introspect(access token)
+      → valid: stay signed in
+      → invalid + refreshToken: POST /refresh → save new pair
+      → else: clear storage → signed out
+  → on sign-out: POST /logout(refreshToken) + clear local storage
+```
+
+Access tokens expire after **15 minutes**. Refresh tokens expire after **7 days** and rotate on each refresh (single-use).
+
+## Workspace entry points
+
+| Workspace | Session continuity | Protected route guard | Auth client |
+|-----------|-------------------|----------------------|-------------|
+| API | `apps/api/src/domains/identity/session.service.ts` | `apps/api/src/middleware/require-auth.ts` | N/A (server) |
+| Web | `apps/web/auth/session-continuity.ts` | `evaluateProtectedRouteGuard()` | `apps/web/auth/auth-client.ts` |
+| Mobile | `apps/mobile/src/auth/sessionContinuity.ts` | `evaluateProtectedRouteGuard()` | `apps/mobile/src/auth/authClient.ts` |
+| Stellar | `apps/stellar-service/src/index.ts` | Challenge/verify boundary | Proxied via API |
+
+## Exercise the flow
+
+```bash
+# Terminal 1 — API
+cd apps/api && pnpm dev
+
+# Terminal 2 — Stellar service (optional, for wallet handoff)
+cd apps/stellar-service && pnpm dev
+
+# Terminal 3 — Web
+cd apps/web && pnpm dev
+```
+
+1. Register or log in at `http://localhost:3000/login`
+2. Visit `/dashboard` — protected route uses shared guard contract
+3. Wait for access token expiry (15m) or manually invalidate token in storage
+4. Reload — client should refresh via `/api/v1/auth/refresh` or redirect to login
+5. Sign out — refresh token revoked server-side, local storage cleared
+
+## Run verification coverage
+
+```bash
+pnpm --filter @themixmatch/api test
+pnpm --filter @themixmatch/web test
+pnpm --filter @themixmatch/mobile test
+pnpm typecheck
+```
+
+## Open questions and next seams
+
+- **Refresh token storage**: In-memory Map today; swap for Redis/DB without changing the repository interface.
+- **HttpOnly cookies**: Clients currently store tokens in localStorage / SecureStore. Production should move to cookie-based sessions.
+- **Stellar verify stub**: stellar-service validates token format and key shape only — on-chain signature verification is a follow-up milestone.
+- **Role-based UI gating**: `requireRole()` exists on API; web/mobile should compose role checks on top of `ProtectedRouteGuard`.
+- **Device fingerprinting**: Not yet attached to refresh records — extension point in `session.service.ts`.
+
+## Related docs
+
+- [Monorepo auth setup](./MONOREPO_AUTH_SETUP.md)
+- [API authentication](../apps/api/docs/AUTHENTICATION.md)
+- [Web auth setup](../apps/web/docs/WEB_AUTH_SETUP.md)
+- [Mobile auth setup](../apps/mobile/docs/MOBILE_AUTH_SETUP.md)

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -107,17 +107,55 @@ export interface IntrospectResponse {
   expiresAt?: string;
 }
 
-// ── Credential errors ────────────────────────────────────────────────────────
+// ── Session logout ───────────────────────────────────────────────────────────
 
-
-export enum CredentialErrorCode {
-  INVALID_CREDENTIALS = "INVALID_CREDENTIALS",
-  ACCOUNT_NOT_FOUND = "ACCOUNT_NOT_FOUND",
-  ACCOUNT_LOCKED = "ACCOUNT_LOCKED",
+export interface SessionLogoutRequest {
+  refreshToken: string;
 }
 
-export interface CredentialErrorContract {
-  code: CredentialErrorCode;
-  message: string;
-  retryAfter?: number;
+export interface SessionLogoutResponse {
+  loggedOut: boolean;
 }
+
+// ── Route guard context ────────────────────────────────────────────────────────
+
+/** Claims attached to protected routes after access-token verification. */
+export interface AuthenticatedRequestContext {
+  userId: string;
+  role: UserRole;
+}
+
+/** Client-side outcome when restoring or validating a stored session. */
+export type SessionContinuityOutcome =
+  | { status: "valid"; session: AuthSession }
+  | { status: "refreshed"; session: AuthSession }
+  | { status: "expired" };
+
+// ── Stellar auth boundary (auth-to-Stellar handoff) ───────────────────────────
+
+export interface StellarAuthChallengeRequest {
+  stellarPublicKey: string;
+}
+
+export interface StellarAuthChallengeResponse {
+  transactionXdr: string;
+  networkPassphrase: string;
+  expiresAt: string;
+}
+
+export interface StellarAuthVerifyRequest {
+  sessionToken: string;
+  stellarPublicKey: string;
+}
+
+export interface StellarAuthVerifyResponse {
+  verified: boolean;
+  stellarAccountId: string;
+  linkedAt: string;
+}
+
+export type StellarAuthChallengeApiResponse = ApiResponse<StellarAuthChallengeResponse>;
+export type StellarAuthVerifyApiResponse = ApiResponse<StellarAuthVerifyResponse>;
+export type SessionRefreshApiResponse = ApiResponse<SessionRefreshResponse>;
+export type SessionLogoutApiResponse = ApiResponse<SessionLogoutResponse>;
+export type IntrospectApiResponse = ApiResponse<IntrospectResponse>;

--- a/packages/types/src/session.types.ts
+++ b/packages/types/src/session.types.ts
@@ -1,7 +1,19 @@
 /**
  * Session-level contracts shared across API and client workspaces.
- * AUTH-052 — session refresh, introspection, and route gating.
+ * AUTH-069–072 — session refresh, introspection, logout, and route gating.
  */
+
+/** Guard contract for protected routes — shared vocabulary across web, mobile, and API. */
+export interface ProtectedRouteGuard {
+  /** Whether the caller may access the protected resource. */
+  allowed: boolean;
+  /** Present when allowed — the authenticated user id. */
+  userId?: string;
+  /** Present when allowed — the authenticated user role. */
+  role?: string;
+  /** Machine-readable reason when access is denied. */
+  reason?: "missing_session" | "expired_session" | "invalid_session" | "insufficient_role";
+}
 
 export interface RefreshTokenRecord {
   /** jti — unique token id */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.100.14
+        version: 5.100.14(react@19.2.6)
       '@themixmatch/types':
         specifier: workspace:*
         version: link:../../packages/types
@@ -164,6 +167,9 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.2.6(react@19.2.6)
+      zustand:
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
       '@types/node':
         specifier: ^24.3.0
@@ -174,6 +180,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.9
         version: 19.2.3(@types/react@19.2.15)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@24.12.4)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/config: {}
 
@@ -1733,6 +1742,14 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tanstack/query-core@5.100.14':
+    resolution: {integrity: sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==}
+
+  '@tanstack/react-query@5.100.14':
+    resolution: {integrity: sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/jest-native@5.4.3':
     resolution: {integrity: sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==}
@@ -4508,6 +4525,24 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@0no-co/graphql.web@1.2.0': {}
@@ -6278,6 +6313,13 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/query-core@5.100.14': {}
+
+  '@tanstack/react-query@5.100.14(react@19.2.6)':
+    dependencies:
+      '@tanstack/query-core': 5.100.14
+      react: 19.2.6
 
   '@testing-library/jest-native@5.4.3(react-native@0.81.6(@babel/core@7.29.7)(@types/react@19.2.15)(react@19.2.6))(react-test-renderer@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -9349,3 +9391,9 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@4.4.3: {}
+
+  zustand@5.0.14(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)):
+    optionalDependencies:
+      '@types/react': 19.2.15
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)


### PR DESCRIPTION
## Summary

- Adds shared session contracts (refresh, introspect, logout, Stellar handoff, route guards) in `packages/types`
- Implements API runtime for logout and Stellar handshake route; wires `STELLAR_SERVICE_URL` for Stellar proxy
- Adds session continuity + protected-route guard seam in web and mobile clients
- Adds regression tests across API, web, and mobile exercising happy and failure paths
- Documents session lifecycle for contributors across the monorepo

closes: #404
closes: #405
closes: #406
closes: #407

## What changed

- **packages/types**: Stellar auth DTOs, logout contracts, `SessionContinuityOutcome`, `ProtectedRouteGuard`; removed duplicate credential error definitions
- **apps/api**: `POST /auth/logout`, `GET /auth/handshake`, logout service, Stellar env config, session/guard tests
- **apps/web**: Fixed `auth-storage.ts`, extended auth client, session continuity bootstrap, dashboard guard, vitest coverage
- **apps/mobile**: refresh/introspect/logout client methods, session continuity on launch, tests
- **apps/stellar-service**: typed challenge/verify responses; boundary docs
- **docs**: `SESSION_LIFECYCLE.md` + updated monorepo/per-app auth guides

## Why

Later MVP features need a single protected-session seam across web, mobile, API, and Stellar rather than per-app guard logic. This PR establishes the shared contract, runtime behavior, tests, and contributor docs for the Authentication milestone.

## Testing performed

- `pnpm --filter @themixmatch/api exec vitest run` (session.service, session.handler, require-auth, stellar.handler) — 16 passed
- `pnpm --filter @themixmatch/web test` — 5 passed
- `pnpm --filter @themixmatch/mobile test` — 10 passed
- `pnpm --filter @themixmatch/api typecheck` — passed

## Risks considered

- Refresh token store remains in-memory (documented extension point)
- Stellar verify is still a format stub — no on-chain signature validation yet
- Client-side route guards only (no Next.js middleware yet)

## Edge cases handled

- Expired access token → refresh attempt → clear session on failure
- Logout is idempotent when refresh token is invalid/already revoked
- Introspect 401 treated as invalid session on clients
- Local mobile mock supports offline session continuity
