### PR TITLE
Aligh session

### DIFF
--- a/apps/web/auth/align-session.ts
+++ b/apps/web/auth/align-session.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { UserRole } from "@themixmatch/types";
+import type { AuthSession } from "@themixmatch/types";
+
+const { mockIntrospectSession, mockRefreshSession } = vi.hoisted(() => ({
+  mockIntrospectSession: vi.fn(),
+  mockRefreshSession: vi.fn(),
+}));
+
+vi.mock("./auth-client", () => ({
+  introspectSession: (...args: unknown[]) => mockIntrospectSession(...args),
+  refreshSession: (...args: unknown[]) => mockRefreshSession(...args),
+}));
+
+import { ensureSessionContinuity, evaluateProtectedRouteGuard } from "./session-continuity";
+
+const storedSession: AuthSession = {
+  token: "access.token",
+  refreshToken: "refresh.token",
+  user: {
+    id: "user-1",
+    name: "dj",
+    email: "dj@example.com",
+    role: UserRole.DJ,
+    onboardingCompleted: false,
+  },
+  session: {
+    userId: "user-1",
+    role: UserRole.DJ,
+    onboardingCompleted: false,
+    issuedAt: "2026-06-01T12:00:00.000Z",
+    wallet: {
+      service: "stellar-service",
+      status: "unlinked",
+      networkPassphrase: "Test SDF Network ; September 2015",
+      horizonUrl: "https://horizon-testnet.stellar.org",
+      availableWallets: ["phantom", "freighter"],
+    },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ensureSessionContinuity", () => {
+  it("returns valid when introspection succeeds", async () => {
+    mockIntrospectSession.mockResolvedValue({ valid: true, userId: "user-1", role: UserRole.DJ });
+
+    await expect(ensureSessionContinuity(storedSession)).resolves.toEqual({
+      status: "valid",
+      session: storedSession,
+    });
+  });
+
+  it("refreshes the session when introspection fails but refresh succeeds", async () => {
+    mockIntrospectSession.mockResolvedValue({ valid: false });
+    mockRefreshSession.mockResolvedValue({
+      accessToken: "new.access.token",
+      refreshToken: "new.refresh.token",
+      expiresAt: "2026-06-01T12:15:00.000Z",
+    });
+
+    const outcome = await ensureSessionContinuity(storedSession);
+
+    expect(outcome.status).toBe("refreshed");
+    if (outcome.status === "refreshed") {
+      expect(outcome.session.token).toBe("new.access.token");
+      expect(outcome.session.refreshToken).toBe("new.refresh.token");
+    }
+  });
+
+  it("returns expired when refresh is unavailable", async () => {
+    mockIntrospectSession.mockResolvedValue({ valid: false });
+    mockRefreshSession.mockRejectedValue(new Error("refresh failed"));
+
+    await expect(ensureSessionContinuity(storedSession)).resolves.toEqual({ status: "expired" });
+  });
+});
+
+describe("evaluateProtectedRouteGuard", () => {
+  it("denies access when no session is present", () => {
+    expect(evaluateProtectedRouteGuard(null)).toEqual({
+      allowed: false,
+      reason: "missing_session",
+    });
+  });
+
+  it("allows access when a session token is present", () => {
+    expect(evaluateProtectedRouteGuard(storedSession)).toEqual({
+      allowed: true,
+      userId: "user-1",
+      role: UserRole.DJ,
+    });
+  });
+});

--- a/apps/web/auth/align.tsx
+++ b/apps/web/auth/align.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { UserRole, type SignupRequest } from "@themixmatch/types";
+import { signup } from "@/auth/auth-client";
+import { useAuth } from "@/auth/auth-context";
+
+export default function Align() {
+  const router = useRouter();
+  const { signIn } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [role, setRole] = useState<UserRole | "">("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const payload: SignupRequest = {
+      email,
+      password,
+      role: role as UserRole,
+    };
+
+    try {
+      const response = await signup(payload);
+      if (!response.success) {
+        setError(response.message ?? "Unable to create account.");
+        return;
+      }
+
+      signIn(response.data);
+      router.push("/dashboard");
+    } catch (err) {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="page-shell">
+      <section className="hero-card">
+        <h1 className="headline">Create your MixMatch account</h1>
+        <p className="lede">
+          Create a secure auth session and continue to your dashboard.
+        </p>
+
+        <form onSubmit={handleSubmit} className="signup-form">
+          <div className="form-group">
+            <label htmlFor="email">Email</label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              disabled={loading}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="password">Password</label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              disabled={loading}
+              minLength={8}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="role">Role</label>
+            <select
+              id="role"
+              value={role}
+              onChange={(event) => setRole(event.target.value as UserRole)}
+              required
+              disabled={loading}
+            >
+              <option value="">Select your role</option>
+              <option value={UserRole.DJ}>DJ</option>
+              <option value={UserRole.PLANNER}>Planner</option>
+              <option value={UserRole.MUSIC_LOVER}>Music Lover</option>
+            </select>
+          </div>
+
+          {error && <div className="error-message">{error}</div>}
+
+          <button type="submit" disabled={loading}>
+            {loading ? "Creating account..." : "Create account"}
+          </button>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/auth/expection-session.tsx
+++ b/apps/web/auth/expection-session.tsx
@@ -1,0 +1,51 @@
+import type { AuthSession, ProtectedRouteGuard, SessionContinuityOutcome } from "@themixmatch/types";
+
+import { introspectSession, refreshSession } from "./auth-client";
+
+/**
+ * Shared session seam — validates a stored session and refreshes when needed.
+ * Web and mobile clients follow the same contract-driven flow.
+ */
+export async function ensureSessionContinuity(
+  stored: AuthSession,
+): Promise<SessionContinuityOutcome> {
+  const introspection = await introspectSession(stored.token);
+  if (introspection.valid) {
+    return { status: "valid", session: stored };
+  }
+
+  if (!stored.refreshToken) {
+    return { status: "expired" };
+  }
+
+  try {
+    const refreshed = await refreshSession(stored.refreshToken);
+    const nextSession: AuthSession = {
+      ...stored,
+      token: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      session: {
+        ...stored.session,
+        issuedAt: new Date().toISOString(),
+      },
+    };
+    return { status: "refreshed", session: nextSession };
+  } catch {
+    return { status: "expired" };
+  }
+}
+
+/** Maps a stored session to the shared protected-route guard contract. */
+export function evaluateProtectedRouteGuard(
+  session: AuthSession | null,
+): ProtectedRouteGuard {
+  if (!session?.token) {
+    return { allowed: false, reason: "missing_session" };
+  }
+
+  return {
+    allowed: true,
+    userId: session.user.id,
+    role: session.user.role,
+  };
+}

--- a/apps/web/auth/expection-storage.ts
+++ b/apps/web/auth/expection-storage.ts
@@ -1,0 +1,35 @@
+import type { AuthSession } from "@themixmatch/types";
+
+const STORAGE_KEY = "mixmatch:auth-session";
+
+function isValidSession(value: unknown): value is AuthSession {
+  if (typeof value !== "object" || value === null) return false;
+  const parsed = value as AuthSession;
+  return Boolean(parsed.token && parsed.user && parsed.session);
+}
+
+export const authStorage = {
+  loadSession(): AuthSession | null {
+    if (typeof window === "undefined") return null;
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isValidSession(parsed) ? parsed : null;
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+  },
+
+  saveSession(session: AuthSession): void {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+  },
+
+  clearSession(): void {
+    if (typeof window === "undefined") return;
+    localStorage.removeItem(STORAGE_KEY);
+  },
+};


### PR DESCRIPTION

 Align session lookup, refresh, logout, and guard contracts across API, web, and mobile

Summary
The repository reset leaves this area intentionally blank. The starter needs a real notion of protected sessions so later MVP features do not invent separate guard logic in each workspace. Focus on the seams between web, mobile, API, and shared packages rather than solving auth in only one runtime. Define or extend shared types, request shapes, and response boundaries so every app can build on the same authentication vocabulary.

Scope
Touch the relevant code in apps/api, apps/web, apps/mobile, packages/types.
Treat this as contributor-facing baseline work that should be clear, reviewable, and easy to extend.
Keep the work centered on the Authentication milestone and the current hackathon MVP direction.
Acceptance Criteria
A complete implementation should include:

Shared request and response types exist where this flow needs them, and app-local copies are avoided.
The targeted auth path behaves consistently in the workspace named by the issue title.
The implementation leaves clear seams for follow-up work instead of baking milestone-specific hacks into one app.
A new contributor can locate the relevant contract entry points without reading legacy history.
Source manifest key: AUTH-066
closes #401