### PR TITLE
feat(types): stabilize shared auth envelope contract

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -79,6 +79,9 @@ interface ApiError {
   code: string;
   message: string;
 }
+
+// `ApiEnvelope<T>` is a compatibility alias for `ApiSuccess<T> | ApiError`.
+type ApiEnvelope<T> = ApiSuccess<T> | ApiError;
 ```
 
 ### Auth session payload

--- a/packages/types/auth/api-envelope.ts
+++ b/packages/types/auth/api-envelope.ts
@@ -1,0 +1,1 @@
+export type { ApiEnvelope } from "./api-envelope.types.js";

--- a/packages/types/auth/api-envelope.types.ts
+++ b/packages/types/auth/api-envelope.types.ts
@@ -1,0 +1,1 @@
+export type { ApiEnvelope } from "../src/auth-envelope.types.js";

--- a/packages/types/src/api-envelope.ts
+++ b/packages/types/src/api-envelope.ts
@@ -1,0 +1,1 @@
+export type { ApiEnvelope } from "./auth-envelope.types.js";

--- a/packages/types/src/auth-envelope.types.ts
+++ b/packages/types/src/auth-envelope.types.ts
@@ -13,3 +13,10 @@ export interface ApiError {
 export type ApiResponse<T> =
   | ApiSuccess<T>
   | ApiError;
+
+/**
+ * Backwards-compatible alias used by older auth clients and docs.
+ * Keeping this alongside ApiResponse avoids duplicating envelope shapes
+ * across web, mobile, and API workspaces.
+ */
+export type ApiEnvelope<T> = ApiResponse<T>;


### PR DESCRIPTION
This PR adds a shared `ApiEnvelope<T>` alias in the types package so the auth clients and API can use one stable envelope shape while remaining compatible with existing callers.

It keeps the change intentionally small and lays the contract groundwork for the Authentication milestone.

Closes #449
Closes #450
Closes #451
Closes #452
