### PR TITLE
fix(auth): short-circuit expired sessions in web auth bootstrap

### DIFF
--- a/apps/web/auth/session-continuity.test.ts
+++ b/apps/web/auth/session-continuity.test.ts
@@ -76,6 +76,28 @@ describe("ensureSessionContinuity", () => {
 
     await expect(ensureSessionContinuity(storedSession)).resolves.toEqual({ status: "expired" });
   });
+
+  it("refreshes an expired session without calling introspection first", async () => {
+    const expiredSession: AuthSession = {
+      ...storedSession,
+      session: {
+        ...storedSession.session,
+        issuedAt: new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+      },
+    };
+
+    mockRefreshSession.mockResolvedValue({
+      accessToken: "refreshed.access.token",
+      refreshToken: "refreshed.refresh.token",
+      expiresAt: "2026-06-01T13:15:00.000Z",
+    });
+
+    const outcome = await ensureSessionContinuity(expiredSession);
+
+    expect(mockIntrospectSession).not.toHaveBeenCalled();
+    expect(mockRefreshSession).toHaveBeenCalledWith("refresh.token");
+    expect(outcome.status).toBe("refreshed");
+  });
 });
 
 describe("evaluateProtectedRouteGuard", () => {

--- a/apps/web/auth/session-continuity.ts
+++ b/apps/web/auth/session-continuity.ts
@@ -1,6 +1,7 @@
 import type { AuthSession, ProtectedRouteGuard, SessionContinuityOutcome } from "@themixmatch/types";
 
 import { introspectSession, refreshSession } from "./auth-client";
+import { isSessionExpired } from "./auth-session";
 
 /**
  * Shared session seam — validates a stored session and refreshes when needed.
@@ -9,6 +10,30 @@ import { introspectSession, refreshSession } from "./auth-client";
 export async function ensureSessionContinuity(
   stored: AuthSession,
 ): Promise<SessionContinuityOutcome> {
+  if (isSessionExpired(stored)) {
+    if (!stored.refreshToken) {
+      return { status: "expired" };
+    }
+
+    try {
+      const refreshed = await refreshSession(stored.refreshToken);
+      return {
+        status: "refreshed",
+        session: {
+          ...stored,
+          token: refreshed.accessToken,
+          refreshToken: refreshed.refreshToken,
+          session: {
+            ...stored.session,
+            issuedAt: new Date().toISOString(),
+          },
+        },
+      };
+    } catch {
+      return { status: "expired" };
+    }
+  }
+
   const introspection = await introspectSession(stored.token);
   if (introspection.valid) {
     return { status: "valid", session: stored };

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -79,6 +79,9 @@ interface ApiError {
   code: string;
   message: string;
 }
+
+// `ApiEnvelope<T>` is a compatibility alias for `ApiSuccess<T> | ApiError`.
+type ApiEnvelope<T> = ApiSuccess<T> | ApiError;
 ```
 
 ### Auth session payload

--- a/packages/types/auth/api-envelope.ts
+++ b/packages/types/auth/api-envelope.ts
@@ -1,0 +1,1 @@
+export type { ApiEnvelope } from "./api-envelope.types.js";

--- a/packages/types/auth/api-envelope.types.ts
+++ b/packages/types/auth/api-envelope.types.ts
@@ -1,0 +1,1 @@
+export type { ApiEnvelope } from "../src/auth-envelope.types.js";

--- a/packages/types/src/api-envelope.ts
+++ b/packages/types/src/api-envelope.ts
@@ -1,0 +1,1 @@
+export type { ApiEnvelope } from "./auth-envelope.types.js";

--- a/packages/types/src/auth-envelope.types.ts
+++ b/packages/types/src/auth-envelope.types.ts
@@ -13,3 +13,10 @@ export interface ApiError {
 export type ApiResponse<T> =
   | ApiSuccess<T>
   | ApiError;
+
+/**
+ * Backwards-compatible alias used by older auth clients and docs.
+ * Keeping this alongside ApiResponse avoids duplicating envelope shapes
+ * across web, mobile, and API workspaces.
+ */
+export type ApiEnvelope<T> = ApiResponse<T>;


### PR DESCRIPTION
Summary\n- Refresh expired sessions before introspection so the bootstrap path handles stale credentials deterministically.\n- Keep route gating using the shared auth-session seam.\n- Add a regression test that proves expired sessions refresh without calling introspection first.\n\nValidation\n- Added a focused session continuity test for the expired-session path.\n\nCloses #392\nCloses #393\nCloses #394\nCloses #395