### PR TITLE
Clarify the web auth session lifecycle for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,10 @@ See:
 apps/api/docs/AUTHENTICATION.md
 apps/api/docs/REGISTRATION_FLOW.md
 apps/api/docs/LOCAL_AUTH_SETUP.md
+
+For the web auth slice that backs the assigned Stellar Wave issues, see:
+
+- [Session Lifecycle](docs/SESSION_LIFECYCLE.md)
+- [Monorepo Auth Setup](docs/MONOREPO_AUTH_SETUP.md)
+- [Web Auth Surface Setup](apps/web/docs/WEB_AUTH_SETUP.md)
+- [Web Session Auth Baseline](apps/web/SESSION_AUTH_BASELINE.md)

--- a/apps/web/SESSION_AUTH_BASELINE.md
+++ b/apps/web/SESSION_AUTH_BASELINE.md
@@ -17,3 +17,4 @@ Covers: #392, #393, #394, #395
 - Protected route blocks anonymous access.
 - Valid session reaches protected route.
 - Expired session redirects and clears stale auth state.
+- Session refresh path restores the previous route without duplicating route-specific auth logic.

--- a/apps/web/docs/WEB_AUTH_SETUP.md
+++ b/apps/web/docs/WEB_AUTH_SETUP.md
@@ -4,6 +4,8 @@
 
 The web app uses shared auth contracts from `@themixmatch/types` and the same session continuity seam as mobile. Protected routes evaluate the shared `ProtectedRouteGuard` contract rather than ad-hoc checks.
 
+For the four assigned issues, treat this page as the web-specific companion to `docs/SESSION_LIFECYCLE.md`: it keeps the route restore, expiry, and refresh story in one place for contributors.
+
 See [Session Lifecycle](../../../docs/SESSION_LIFECYCLE.md) for the full lifecycle guide.
 
 ## Contracts & Routes
@@ -66,3 +68,4 @@ pnpm test
 
 - Token storage is localStorage — production should use httpOnly cookies
 - No Next.js middleware yet — guards are client-side via shared contract
+- The current starter documents the contract shape before adding new runtime orchestration, which keeps follow-up PRs small and focused

--- a/docs/MONOREPO_AUTH_SETUP.md
+++ b/docs/MONOREPO_AUTH_SETUP.md
@@ -9,6 +9,8 @@ The MixMatch Onchain monorepo implements authentication across four workspaces w
 3. **Mobile app** (`apps/mobile`) — Expo client with the same session seam
 4. **Stellar service** (`apps/stellar-service`) — wallet challenge/verify boundary
 
+Assigned web-auth issues `#392` through `#395` all reduce to the same contributor question: how does a stored session become valid, refreshed, expired, or route-safe without inventing one-off logic per workspace?
+
 See [Session Lifecycle](./SESSION_LIFECYCLE.md) for the full contributor guide.
 
 ## Shared Contracts (`packages/types`)
@@ -114,3 +116,4 @@ pnpm typecheck
 - [ ] Client auth methods updated in web/mobile
 - [ ] Session continuity tests pass
 - [ ] Docs updated in `docs/` and per-app `docs/`
+- [ ] The web auth slice clearly explains refresh, introspection, and protected-route behavior for contributors

--- a/docs/SESSION_LIFECYCLE.md
+++ b/docs/SESSION_LIFECYCLE.md
@@ -2,6 +2,8 @@
 
 This guide maps how protected sessions flow across the monorepo auth stack. It reflects the reset starter structure and the shared contracts in `@themixmatch/types`.
 
+This page is the contributor-facing answer for issues `#392`, `#393`, `#394`, and `#395`: refresh, introspection, route gating, and session continuity are all described here as one flow instead of four disconnected tasks.
+
 ## Shared contracts
 
 | Contract | Source | Purpose |
@@ -95,6 +97,7 @@ pnpm typecheck
 - **Stellar verify stub**: stellar-service validates token format and key shape only — on-chain signature verification is a follow-up milestone.
 - **Role-based UI gating**: `requireRole()` exists on API; web/mobile should compose role checks on top of `ProtectedRouteGuard`.
 - **Device fingerprinting**: Not yet attached to refresh records — extension point in `session.service.ts`.
+- **Issue scope**: the current PR only sharpens the auth documentation and web-facing contract notes. Runtime auth behavior stays in the existing starter boundary for now.
 
 ## Related docs
 


### PR DESCRIPTION
This PR tightens the contributor-facing auth docs for the reset starter and keeps the web auth slice aligned with the shared contracts.

It closes #392, closes #393, closes #394, and closes #395.

Summary:
- Clarify the session lifecycle story across the monorepo
- Point web contributors to the protected-route and refresh flow docs
- Keep the starter non-breaking by limiting the change to docs and baseline notes