### PR TITLE
API auth: session expiry contract

### DIFF
--- a/apps/api/src/contracts/session.contract.ts
+++ b/apps/api/src/contracts/session.contract.ts
@@ -1,0 +1,7 @@
+import type { MixMatchError } from "@mixmatch/types";
+
+export type UnauthorizedErrorResponse = {
+  success: false;
+  error: MixMatchError;
+};
+

--- a/apps/api/src/middleware/auth.middleware.ts
+++ b/apps/api/src/middleware/auth.middleware.ts
@@ -5,31 +5,19 @@ import {
   TokenExpiredError,
   verifyToken,
 } from '../services/jwt.service';
+import { extractBearerToken } from '../utils/session-guard';
+import { jwtUnauthorizedError } from '../utils/session-errors';
 
 export interface AuthenticatedRequestUser {
   userId: string;
   role: UserRole;
 }
 
-const extractBearerToken = (authorizationHeader?: string): string | null => {
-  if (!authorizationHeader) {
-    return null;
-  }
-
-  const [scheme, token] = authorizationHeader.split(' ');
-
-  if (scheme !== 'Bearer' || !token) {
-    return null;
-  }
-
-  return token;
-};
-
 export const requireAuth = (req: Request, res: Response, next: NextFunction): void => {
   const token = extractBearerToken(req.header('authorization'));
 
   if (!token) {
-    res.status(401).json({ message: 'Unauthorized: missing or invalid token' });
+    next(jwtUnauthorizedError());
     return;
   }
 
@@ -44,18 +32,18 @@ export const requireAuth = (req: Request, res: Response, next: NextFunction): vo
     next();
   } catch (error) {
     if (error instanceof TokenExpiredError || error instanceof JsonWebTokenError) {
-      res.status(401).json({ message: 'Unauthorized: missing or invalid token' });
+      next(jwtUnauthorizedError());
       return;
     }
 
-    res.status(500).json({ message: 'Internal server error' });
+    next(error);
   }
 };
 
 export const requireRole = (roles: UserRole[]) => {
   return (req: Request, res: Response, next: NextFunction): void => {
     if (!req.user) {
-      res.status(401).json({ message: 'Unauthorized: missing or invalid token' });
+      next(jwtUnauthorizedError());
       return;
     }
 

--- a/apps/api/src/utils/session-errors.ts
+++ b/apps/api/src/utils/session-errors.ts
@@ -1,0 +1,7 @@
+import { AuthError } from "./errors";
+
+export function jwtUnauthorizedError(requestId?: string): AuthError {
+  // We don't distinguish invalid vs expired at this boundary; clients handle both as session reset.
+  return AuthError.tokenExpired(requestId);
+}
+

--- a/apps/api/src/utils/session-guard.ts
+++ b/apps/api/src/utils/session-guard.ts
@@ -1,0 +1,14 @@
+export const extractBearerToken = (authorizationHeader?: string): string | null => {
+  if (!authorizationHeader) {
+    return null;
+  }
+
+  const [scheme, token] = authorizationHeader.split(" ");
+
+  if (scheme !== "Bearer" || !token) {
+    return null;
+  }
+
+  return token;
+};
+

--- a/apps/api/tests/auth.integration.test.ts
+++ b/apps/api/tests/auth.integration.test.ts
@@ -109,4 +109,6 @@ test('expired/invalid session token returns 401 contract', async () => {
     .get('/auth/me')
     .set('Authorization', 'Bearer invalid-or-expired-token');
   assert.equal(res.status, 401);
+  assert.equal(res.body.success, false);
+  assert.equal(typeof res.body.error?.code, 'string');
 });


### PR DESCRIPTION
Routes auth failures through the standard API error envelope so clients can reliably detect session expiry and restore routes.

- `requireAuth`/`requireRole` now call `next(AuthError...)` instead of returning ad-hoc JSON
- Integration test asserts the 401 response uses `{ success: false, error: { code } }`

Closes #388
Closes #389
Closes #390
Closes #391
