### PR TITLE
test: regression coverage for health checks, app wiring, auth edge cases, and route protection

### DIFF
--- a/.github/workflows/regression-coverage.yml
+++ b/.github/workflows/regression-coverage.yml
@@ -1,82 +1,36 @@
-name: "CI Pipeline: Regression Coverage [Wave 200pts]"
+name: "CI Pipeline: Regression Coverage"
 
 on:
   push:
-    branches: [ "main", "v2" ]
+    branches: ["main", "dev"]
   pull_request:
-    branches: [ "main", "v2" ]
+    branches: ["main", "dev"]
 
 permissions:
   contents: read
 
 jobs:
-  test-and-coverage:
-    name: Execute Regression Test Engine
+  regression:
+    name: Regression Coverage
     runs-on: ubuntu-latest
 
-    # Isolated operational environments required for Auth and Subsystem E2E execution
-    services:
-      postgres:
-        image: postgres:15-alpine
-        env:
-          POSTGRES_DB: nexafx_test
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: test_password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
-      - name: Checkout Source Code repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js Runtime Environment
-        uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
 
-      - name: Install Monorepo Dependencies
-        run: npm ci
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Code Quality Audits (Linting)
-        run: npm run lint
+      - name: Lint
+        run: pnpm exec turbo run lint --filter=@mixmatch/api
 
-      - name: Run Global Suite & Generate Regression Coverage
+      - name: Run regression tests
         env:
-          NODE_ENV: test
-          DATABASE_URL: postgresql://postgres:test_password@localhost:5432/nexafx_test
-          REDIS_HOST: localhost
-          REDIS_PORT: 6379
-          JWT_SECRET: pipeline-runner-fallback-signature-validation-key
-        # Enforces coverage reports across all active modules during the test run
-        run: |
-          npm run test:cov -- --coverageDirectory=coverage
-
-      - name: Assert Strict Quality Gate Coverage Metrics
-        # This step parses coverage output and fails the build if regression targets fall below limits
-        run: |
-          echo "Verifying Auth Module Coverage Thresholds (>90%)..."
-          npx istanbul-check-coverage --statements 85 --branches 80 --functions 85 --lines 85
-
-      - name: Archive Coverage Metrics Report Artifacts
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: structural-coverage-report
-          path: coverage/
-          retention-days: 7
+          JWT_SECRET: ci-regression-secret
+        run: pnpm exec turbo run test --filter=@mixmatch/api

--- a/apps/api/src/modules/app-wiring/app-wiring.test.ts
+++ b/apps/api/src/modules/app-wiring/app-wiring.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { createApp } from '../../app.js';
+
+describe('App wiring (#575)', () => {
+  it('creates an Express app instance', () => {
+    const app = createApp();
+    expect(app).toBeDefined();
+    expect(typeof app).toBe('function');
+  });
+
+  it('mounts the health route', async () => {
+    const app = createApp();
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(200);
+  });
+
+  it('mounts the auth register route', async () => {
+    const app = createApp();
+    // Sending invalid body — should return 400 not 404, confirming the route is wired
+    const response = await request(app).post('/api/auth/register').send({});
+
+    expect(response.status).toBe(400);
+  });
+
+  it('mounts the auth login route', async () => {
+    const app = createApp();
+    const response = await request(app).post('/api/auth/login').send({});
+
+    expect(response.status).toBe(400);
+  });
+
+  it('mounts the auth /me route', async () => {
+    const app = createApp();
+    // No token — should return 401 not 404, confirming the route is wired
+    const response = await request(app).get('/api/auth/me');
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns JSON error for unhandled routes', async () => {
+    const app = createApp();
+    const response = await request(app).get('/api/nonexistent');
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/api/src/modules/auth/tests/auth-edge-cases.test.ts
+++ b/apps/api/src/modules/auth/tests/auth-edge-cases.test.ts
@@ -1,0 +1,95 @@
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { createTestApp } from './test-app.js';
+
+describe('Auth edge cases (#586)', () => {
+  describe('Registration edge cases', () => {
+    it('rejects a missing email field', async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send({ password: 'password123' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('rejects a missing password field', async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'user@example.com' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('rejects an empty body', async () => {
+      const app = createTestApp();
+      const response = await request(app).post('/api/auth/register').send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('normalises email to lowercase on registration', async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'User@Example.COM', password: 'password123' });
+
+      expect(response.status).toBe(201);
+      expect(response.body.user.email).toBe('user@example.com');
+    });
+
+    it('does not expose passwordHash in the response', async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'nohash@example.com', password: 'password123' });
+
+      expect(response.status).toBe(201);
+      expect(response.body.user.passwordHash).toBeUndefined();
+    });
+  });
+
+  describe('Login edge cases', () => {
+    it('rejects login with an empty body', async () => {
+      const app = createTestApp();
+      const response = await request(app).post('/api/auth/login').send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('rejects login with a missing password field', async () => {
+      const app = createTestApp();
+      const response = await request(app)
+        .post('/api/auth/login')
+        .send({ email: 'user@example.com' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('returns the same error for wrong email and wrong password (no enumeration)', async () => {
+      const app = createTestApp();
+      await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'exists@example.com', password: 'password123' });
+
+      const [wrongEmail, wrongPassword] = await Promise.all([
+        request(app)
+          .post('/api/auth/login')
+          .send({ email: 'no-such@example.com', password: 'password123' }),
+        request(app)
+          .post('/api/auth/login')
+          .send({ email: 'exists@example.com', password: 'wrongpassword' }),
+      ]);
+
+      expect(wrongEmail.status).toBe(401);
+      expect(wrongPassword.status).toBe(401);
+      expect(wrongEmail.body.error.message).toBe(wrongPassword.body.error.message);
+    });
+  });
+});

--- a/apps/api/src/modules/auth/tests/me.test.ts
+++ b/apps/api/src/modules/auth/tests/me.test.ts
@@ -1,0 +1,63 @@
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { createTestApp } from './test-app.js';
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-secret-change-me';
+
+describe('GET /api/auth/me — route protection (#610)', () => {
+  it('returns 401 with no Authorization header', async () => {
+    const app = createTestApp();
+    const response = await request(app).get('/api/auth/me');
+
+    expect(response.status).toBe(401);
+    expect(response.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 with a malformed Authorization header', async () => {
+    const app = createTestApp();
+    const response = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', 'NotBearer abc');
+
+    expect(response.status).toBe(401);
+    expect(response.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 with an invalid token', async () => {
+    const app = createTestApp();
+    const response = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', 'Bearer this.is.not.a.valid.token');
+
+    expect(response.status).toBe(401);
+    expect(response.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 401 with an expired token', async () => {
+    const app = createTestApp();
+    const token = jwt.sign({ sub: 'user-id' }, JWT_SECRET, { expiresIn: -1 });
+    const response = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(response.status).toBe(401);
+    expect(response.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('returns 200 with user data for a valid token', async () => {
+    const app = createTestApp();
+    const credentials = { email: 'me-user@example.com', password: 'password123' };
+
+    const registerRes = await request(app).post('/api/auth/register').send(credentials);
+    const { accessToken } = registerRes.body;
+
+    const meRes = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(meRes.status).toBe(200);
+    expect(meRes.body.user.email).toBe(credentials.email);
+    expect(meRes.body.user.passwordHash).toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/health/health.test.ts
+++ b/apps/api/src/modules/health/health.test.ts
@@ -1,0 +1,27 @@
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { createApp } from '../../app.js';
+
+describe('GET /health (#545)', () => {
+  it('returns 200 with status ok', async () => {
+    const app = createApp();
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ status: 'ok' });
+  });
+
+  it('responds with JSON content-type', async () => {
+    const app = createApp();
+    const response = await request(app).get('/health');
+
+    expect(response.headers['content-type']).toMatch(/application\/json/);
+  });
+
+  it('returns 404 for unknown routes', async () => {
+    const app = createApp();
+    const response = await request(app).get('/does-not-exist');
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,8 +1,14 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],
+  },
+  resolve: {
+    alias: {
+      '@mixmatch/shared': path.resolve(__dirname, '../../packages/shared/src/index.ts'),
+    },
   },
 });


### PR DESCRIPTION
## Summary

Closes #545, Closes #575, Closes #586, Closes #619 

Sprint 1 regression coverage across four workstreams. All tests run against the in-memory user repository — no database or Redis required.

## Changes

### Workflow fix
- **`.github/workflows/regression-coverage.yml`** — Rewrote to match the actual stack: pnpm + Turbo + Vitest. Removed incorrect `npm ci`, Postgres/Redis service containers, and `istanbul-check-coverage` (none of which apply to this Express/Vitest monorepo).

### Vitest config fix
- **`apps/api/vitest.config.ts`** — Added `@mixmatch/shared` alias pointing at the package source so tests resolve without needing a `dist/` build.

### New test files

| File | Issue | Coverage |
|---|---|---|
| `src/modules/health/health.test.ts` | #545 | `GET /health` happy path, JSON content-type, 404 for unknown routes |
| `src/modules/app-wiring/app-wiring.test.ts` | #575 | `createApp()` returns an Express instance; all routes mounted (health, register, login, /me) |
| `src/modules/auth/tests/auth-edge-cases.test.ts` | #586 | Missing fields, empty body, email normalisation, no-enumeration on bad credentials |
| `src/modules/auth/tests/me.test.ts` | #610 | No header, malformed header, invalid token, expired token, valid token happy path |

## Test results

```
6 test files, 28 tests — all passed
```