### PR TITLE
fix: health check test, shared alias, and regression workflow

### DIFF
--- a/.github/workflows/regression-coverage.yml
+++ b/.github/workflows/regression-coverage.yml
@@ -1,27 +1,26 @@
-name: "CI Pipeline: Regression Coverage [Wave 200pts]"
+name: Regression Coverage
 
 on:
   push:
-    branches: [ "main", "v2" ]
+    branches: [main, dev]
   pull_request:
-    branches: [ "main", "v2" ]
+    branches: [main, dev]
 
 permissions:
   contents: read
 
 jobs:
-  test-and-coverage:
-    name: Execute Regression Test Engine
+  regression:
+    name: Regression Test Suite
     runs-on: ubuntu-latest
 
-    # Isolated operational environments required for Auth and Subsystem E2E execution
     services:
       postgres:
         image: postgres:15-alpine
         env:
-          POSTGRES_DB: nexafx_test
+          POSTGRES_DB: mixmatch_test
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: test_password
+          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
         options: >-
@@ -30,53 +29,32 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
-      - name: Checkout Source Code repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js Runtime Environment
-        uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: 'npm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
 
-      - name: Install Monorepo Dependencies
-        run: npm ci
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
-      - name: Code Quality Audits (Linting)
-        run: npm run lint
+      - name: Lint
+        run: pnpm exec turbo run lint
 
-      - name: Run Global Suite & Generate Regression Coverage
+      - name: Test with coverage
         env:
-          NODE_ENV: test
-          DATABASE_URL: postgresql://postgres:test_password@localhost:5432/nexafx_test
-          REDIS_HOST: localhost
-          REDIS_PORT: 6379
-          JWT_SECRET: pipeline-runner-fallback-signature-validation-key
-        # Enforces coverage reports across all active modules during the test run
-        run: |
-          npm run test:cov -- --coverageDirectory=coverage
+          JWT_SECRET: ci-test-secret
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/mixmatch_test
+        run: pnpm exec turbo run test -- --coverage
 
-      - name: Assert Strict Quality Gate Coverage Metrics
-        # This step parses coverage output and fails the build if regression targets fall below limits
-        run: |
-          echo "Verifying Auth Module Coverage Thresholds (>90%)..."
-          npx istanbul-check-coverage --statements 85 --branches 80 --functions 85 --lines 85
-
-      - name: Archive Coverage Metrics Report Artifacts
+      - name: Upload coverage report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: structural-coverage-report
-          path: coverage/
+          name: coverage-report
+          path: apps/api/coverage/
           retention-days: 7

--- a/apps/api/src/health.test.ts
+++ b/apps/api/src/health.test.ts
@@ -1,0 +1,12 @@
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { createApp } from './app.js';
+
+describe('GET /health', () => {
+  it('returns 200 with status ok', async () => {
+    const app = createApp();
+    const response = await request(app).get('/health');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ status: 'ok' });
+  });
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,6 +1,12 @@
+import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@mixmatch/shared': resolve(__dirname, '../../packages/shared/src/index.ts'),
+    },
+  },
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts'],

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -31,10 +31,11 @@ pnpm --filter @mixmatch/stellar test
 
 ### apps/api
 
-The auth module's tests run against an **in-memory user repository**
+The API tests run against an **in-memory user repository**
 (`InMemoryUserRepository`), so they require no database connection and are
 runnable immediately after `pnpm install`. Tests cover:
 
+- Health check: `GET /health` returns `{ status: "ok" }` with HTTP 200
 - Registration: success, duplicate email, invalid input
 - Login: success, invalid password, non-existent account
 
@@ -54,3 +55,17 @@ feature tests exist yet, by design.
 Each GitHub Actions workflow (`.github/workflows/*.yml`) runs install, lint,
 test, and (where applicable) build for its package on every pull request. A
 failing test or build fails the corresponding check and blocks merge.
+
+### Regression coverage workflow
+
+`.github/workflows/regression-coverage.yml` runs the full test suite with
+coverage on every push and pull request to `main` or `dev`. It:
+
+1. Starts a PostgreSQL service container for integration tests that need a database.
+2. Installs dependencies with `pnpm install --frozen-lockfile`.
+3. Runs `turbo lint` across all packages.
+4. Runs `turbo test -- --coverage` to collect coverage reports.
+5. Uploads the `apps/api/coverage/` directory as an artifact retained for 7 days.
+
+The API tests use an in-memory repository, so they run without the database.
+The PostgreSQL service is available for future integration tests that require it.


### PR DESCRIPTION
## Summary

Fixes four Sprint 1 issues in a single PR.

### Changes

**`apps/api/vitest.config.ts`** — add `resolve.alias` so Vitest resolves `@mixmatch/shared` directly from `packages/shared/src/index.ts` at test time, removing the requirement to build the package first. Without this, all API tests fail with _"Failed to resolve entry for package @mixmatch/shared"_ (fixes #631).

**`apps/api/src/health.test.ts`** — new test covering `GET /health` returns HTTP 200 with `{ status: 'ok' }` (closes #544).

**`.github/workflows/regression-coverage.yml`** — complete rewrite:
- Replace `npm ci` / `npm run …` with `pnpm install --frozen-lockfile` and `pnpm exec turbo run`
- Fix DB name from `nexafx_test` → `mixmatch_test`
- Remove Redis service (not used by this codebase)
- Remove `istanbul-check-coverage` step (package does not exist in the repo)
- Upload `apps/api/coverage/` artifact instead of generic `coverage/`

(closes #630)

**`docs/TESTING.md`** — document the health check endpoint under `apps/api` test coverage, and add a _Regression coverage workflow_ section explaining what the workflow does (closes #632).

### Testing

```
pnpm --filter @mixmatch/api test
# 3 test files, 7 tests — all passed
```

Closes #544, 
Closes #630, 
Closes #631, 
Closes #632