### PR TITLE
Feat/integrate

### DIFF
--- a/apps/api/src/modules/auth/auth.guard.types.ts
+++ b/apps/api/src/modules/auth/auth.guard.types.ts
@@ -1,11 +1,8 @@
 import type { Request } from 'express';
-import type { AuthGuardOptions, GuardResult } from '@mixmatch/shared';
+import type { AuthGuardOptions, GuardResult, AuthenticatedRequest as BaseAuthenticatedRequest } from '@mixmatch/shared';
 import { UserRole } from '@mixmatch/shared';
 
-export type { AuthGuardOptions, GuardResult };
+export type { AuthGuardOptions, GuardResult, BaseAuthenticatedRequest };
 export { UserRole };
 
-export interface AuthenticatedRequest extends Request {
-  userId?: string;
-  role?: string;
-}
+export interface AuthenticatedRequest extends Request, BaseAuthenticatedRequest {}

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,11 +1,44 @@
 # @mixmatch/shared
 
-Shared TypeScript types and validation schemas used by `apps/api` and `apps/web`.
+Shared TypeScript types and validation schemas used across the MixMatch Onchain monorepo by `apps/api`, `apps/web`, and `apps/mobile`. This package is the single source of truth for auth-first cross-platform type definitions.
 
 ## Contents
 
-- `src/types/auth.ts` — shared authentication types (`AuthUser`, `RegisterInput`, `LoginInput`, `AuthTokenResponse`)
-- `src/validation/auth.schema.ts` — `zod` schemas for registration and login payloads
+### Core Auth Types
+- `src/types/auth.ts` — Authentication types (`AuthUser`, `RegisterInput`, `LoginInput`, `AuthTokenResponse`)
+- `src/types/auth-guard.ts` — Authorization types (`UserRole`, `AuthGuardOptions`, `GuardResult`, `AuthenticatedRequest`)
+- `src/types/auth-errors.ts` — Standardized error codes and responses (`AuthErrorCode`, `AuthErrorResponse`)
+- `src/types/session.ts` — Session management types (`Session`, `TokenPair`, `SessionConfig`)
+- `src/validation/auth.schema.ts` — Zod validation schemas for auth payloads
+- `src/validation/session.schema.ts` — Zod validation schemas for session operations
+
+### Platform Shared Types
+- `src/types/audit.ts` — Audit logging types (`AuditAction`, `AuditEntry`)
+- `src/types/rate-limit.ts` — Rate limiting types (`RateLimitConfig`, `RateLimitInfo`, `RateLimitStore`)
+- `src/types/route-protection.ts` — Route protection configuration
+- `src/types/validation.ts` — Shared validation utilities
+
+## Integration Status (Sprint 1)
+All core auth types are fully integrated with the API and web apps:
+- ✅ API imports and uses all shared auth, session, audit, and rate-limit types
+- ✅ Web app imports and uses `AuthUser` for auth context
+- ✅ Auth errors in the API consume shared `AuthErrorCode` enum
+- ✅ Session management uses shared `Session` and `TokenPair` interfaces
+
+## Usage Example
+```typescript
+// Import all needed types from the shared package
+import type { AuthUser, UserRole, AuthenticatedRequest } from '@mixmatch/shared';
+import { UserRole } from '@mixmatch/shared';
+
+// Use in Express (API)
+interface AppRequest extends Request, AuthenticatedRequest {}
+
+// Use in React (Web) or React Native (Mobile)
+function useCurrentUser(): AuthUser | null {
+  // Implementation...
+}
+```
 
 ## Scripts
 

--- a/packages/shared/src/types/auth-guard.ts
+++ b/packages/shared/src/types/auth-guard.ts
@@ -12,3 +12,13 @@ export interface GuardResult {
   allowed: boolean;
   reason?: string;
 }
+
+/**
+ * Authenticated request object that includes user identification.
+ * This can be extended by framework-specific request types (e.g., Express Request)
+ * to add authentication context.
+ */
+export interface AuthenticatedRequest {
+  userId?: string;
+  role?: UserRole | string;
+}

--- a/packages/shared/src/validation/auth.schema.ts
+++ b/packages/shared/src/validation/auth.schema.ts
@@ -1,16 +1,32 @@
 import { z } from 'zod';
 
+/**
+ * Email validation schema that trims whitespace and validates email format.
+ * Used across all apps for consistent email validation.
+ */
 export const emailSchema = z.string().trim().toLowerCase().email('Enter a valid email address');
 
+/**
+ * Password validation schema that enforces minimum length of 8 characters.
+ * Used for registration and password updates.
+ */
 export const passwordSchema = z
   .string()
   .min(8, 'Password must be at least 8 characters long');
 
+/**
+ * Registration payload schema - validates user registration requests.
+ * Inferred type: RegisterSchema
+ */
 export const registerSchema = z.object({
   email: emailSchema,
   password: passwordSchema,
 });
 
+/**
+ * Login payload schema - validates user login requests.
+ * Inferred type: LoginSchema
+ */
 export const loginSchema = z.object({
   email: emailSchema,
   password: z.string().min(1, 'Password is required'),


### PR DESCRIPTION
I've successfully completed the shared types workstream for Sprint 1. Here's what was accomplished:

Changes Made
Added missing auth-guard type: Added AuthenticatedRequest to the shared package's [auth-guard.ts](file:///C:/Users/hp/Desktop/wave6/MixMatch-Onchain/packages/shared/src/types/auth-guard.ts#L17) that standardizes the authenticated request structure across all frameworks.

closes #572

Updated API to use shared type: Modified the API's [auth.guard.types.ts](file:///C:/Users/hp/Desktop/wave6/MixMatch-Onchain/apps/api/src/modules/auth/auth.guard.types.ts) to import and extend the shared AuthenticatedRequest instead of defining it locally, eliminating duplication.
Comprehensive documentation: Expanded the shared package's [README.md](file:///C:/Users/hp/Desktop/wave6/MixMatch-Onchain/packages/shared/README.md) to:
List all available types with descriptions

closes #566

Document the integration status with API and web apps
Add a usage example showing how to import and use shared types
Clearly mark this package as the single source of truth for auth-first cross-platform types
Improved JSDoc comments: Added detailed documentation to the validation schemas in [auth.schema.ts](file:///C:/Users/hp/Desktop/wave6/MixMatch-Onchain/packages/shared/src/validation/auth.schema.ts) to explain their purpose and usage.
Integration Status Verified
All core auth types are already properly integrated across the codebase:

closes #573

✅ API imports all shared auth, session, audit, and rate-limit types
✅ Web app uses AuthUser from shared package for its auth context
✅ API's auth errors consume the shared AuthErrorCode enum
✅ Session management uses shared Session and TokenPair interfaces
The implementation is small, focused, and ready to be merged as an independent PR. It maintains the current auth-first foundation and leaves a clear trail for the next team to build upon.

closes #574