### PR TITLE
feat: token persistence core flow, auth shell edge cases, and test harness hardening

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -14,6 +14,21 @@ model User {
   role         String   @default("USER")
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+  sessions     Session[]
 
   @@map("users")
+}
+
+model Session {
+  id           String   @id @default(uuid())
+  userId       String
+  refreshToken String   @unique
+  expiresAt    DateTime
+  createdAt    DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("sessions")
 }

--- a/apps/api/src/modules/auth/auth.routes.ts
+++ b/apps/api/src/modules/auth/auth.routes.ts
@@ -1,16 +1,18 @@
 import { Router } from 'express';
+import { PrismaClient } from '@prisma/client';
 import { asyncHandler } from '../../shared/middleware/async-handler.js';
 import { requireAuth, type AuthenticatedRequest } from '../../shared/middleware/auth.middleware.js';
 import { PrismaUserRepository } from '../users/users.repository.js';
 import { AuthController } from './auth.controller.js';
 import { AuthService } from './auth.service.js';
-import { InMemorySessionStore } from './session.store.js';
+import { PrismaSessionStore } from './session.store.js';
 import { SessionService } from './session.service.js';
 import { UserRole } from '@mixmatch/shared';
 import { allowOwnership, requireRole } from './auth.guard.js';
 
 export function createAuthRouter(): Router {
-  const sessionStore = new InMemorySessionStore();
+  const prisma = new PrismaClient();
+  const sessionStore = new PrismaSessionStore(prisma);
   const sessionService = new SessionService(sessionStore);
   const authService = new AuthService(new PrismaUserRepository(), sessionService);
   const controller = new AuthController(authService);

--- a/apps/api/src/modules/auth/session.store.ts
+++ b/apps/api/src/modules/auth/session.store.ts
@@ -1,3 +1,4 @@
+import { PrismaClient } from '@prisma/client';
 import type { Session } from './session.types.js';
 
 export interface SessionStore {
@@ -63,5 +64,57 @@ export class InMemorySessionStore implements SessionStore {
     for (const id of toDelete) {
       await this.delete(id);
     }
+  }
+}
+
+export class PrismaSessionStore implements SessionStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(session: Session): Promise<void> {
+    await this.prisma.session.create({
+      data: {
+        id: session.id,
+        userId: session.userId,
+        refreshToken: session.refreshToken,
+        expiresAt: new Date(session.expiresAt),
+        createdAt: new Date(session.createdAt),
+      },
+    });
+  }
+
+  async findByRefreshTokenHash(hash: string): Promise<Session | null> {
+    const record = await this.prisma.session.findUnique({
+      where: { refreshToken: hash },
+    });
+    if (!record) return null;
+    return {
+      id: record.id,
+      userId: record.userId,
+      refreshToken: record.refreshToken,
+      expiresAt: record.expiresAt.toISOString(),
+      createdAt: record.createdAt.toISOString(),
+    };
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await this.prisma.session.delete({ where: { id } });
+    } catch {
+      // record already removed — idempotent by design
+    }
+  }
+
+  async deleteAllByUserId(userId: string): Promise<void> {
+    await this.prisma.session.deleteMany({ where: { userId } });
+  }
+
+  async countByUserId(userId: string): Promise<number> {
+    return this.prisma.session.count({ where: { userId } });
+  }
+
+  async cleanupExpired(): Promise<void> {
+    await this.prisma.session.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
   }
 }

--- a/apps/api/tests/db-test-utils.ts
+++ b/apps/api/tests/db-test-utils.ts
@@ -2,30 +2,31 @@ import { DataSource } from 'typeorm';
 import Redis from 'ioredis';
 
 export class DbTestUtils {
-  /**
-   * Drops transactional row states safely across all tables by executing a cascading truncation sequence
-   */
   static async clearDatabase(dataSource: DataSource): Promise<void> {
-    if (!dataSource.isInitialized) {
-      return;
-    }
+    if (!dataSource?.isInitialized) return;
 
-    const entities = dataSource.entityMetadatas;
-    const tableNames = entities
-      .map((entity) => `"${entity.tableName}"`)
-      .join(', ');
+    try {
+      const entities = dataSource.entityMetadatas;
+      if (!entities?.length) return;
 
-    if (tableNames.length > 0) {
-      await dataSource.query(`TRUNCATE TABLE ${tableNames} CASCADE;`);
+      const tableNames = entities.map((entity) => `"${entity.tableName}"`).join(', ');
+      if (tableNames) {
+        await dataSource.query(`TRUNCATE TABLE ${tableNames} CASCADE;`);
+      }
+    } catch (err) {
+      console.warn('[DbTestUtils] clearDatabase failed:', err instanceof Error ? err.message : err);
     }
   }
 
-  /**
-   * Resets active Redis caches to prevent cross-contamination of rate limit indices or blacklisted sessions
-   */
   static async clearRedis(redisClient: Redis): Promise<void> {
-    if (redisClient && redisClient.status === 'ready') {
-      await redisClient.flushall();
+    if (!redisClient) return;
+
+    try {
+      if (redisClient.status === 'ready') {
+        await redisClient.flushall();
+      }
+    } catch (err) {
+      console.warn('[DbTestUtils] clearRedis failed:', err instanceof Error ? err.message : err);
     }
   }
 }

--- a/apps/api/tests/test-agent-factory.ts
+++ b/apps/api/tests/test-agent-factory.ts
@@ -6,6 +6,13 @@ import { JwtService } from '@nestjs/jwt';
 import * as request from 'supertest';
 import Redis from 'ioredis';
 
+const RETRY_DELAY_MS = 200;
+const MAX_RETRIES = 3;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export class TestHarness {
   public app: INestApplication;
   public dataSource: DataSource;
@@ -21,13 +28,11 @@ export class TestHarness {
     })
       .overrideProvider('STELLAR_VERIFICATION_SERVICE')
       .useValue({
-        verifySignature: () => true, // Bypasses live chain computations globally within this harness
+        verifySignature: () => true,
       })
       .compile();
 
     this.app = moduleFixture.createNestApplication();
-    
-    // Bind exact global constraints to match actual platform behavior
     this.app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
     await this.app.init();
 
@@ -36,34 +41,59 @@ export class TestHarness {
     this.jwtService = moduleFixture.get<JwtService>(JwtService);
   }
 
-  /**
-   * Generates a supertest agent pre-loaded with a legitimate authorization bearer payload 
-   * without calling the signature login flow endpoints.
-   */
   createAuthenticatedAgent(userPayload: { id: string; email: string; role: string }) {
     const token = this.jwtService.sign(
       { sub: userPayload.id, email: userPayload.email, role: userPayload.role },
-      { secret: 'pipeline-runner-fallback-signature-validation-key', expiresIn: '15m' }
+      { secret: 'pipeline-runner-fallback-signature-validation-key', expiresIn: '15m' },
     );
 
     const httpServer = this.app.getHttpServer();
     const agent = request.agent(httpServer);
-    
-    // Attach authentication context parameters globally to all downstream requests
     agent.set('Authorization', `Bearer ${token}`);
-    
+
     return agent;
   }
 
   async close(): Promise<void> {
-    if (this.dataSource?.isInitialized) {
-      await this.dataSource.destroy();
+    const closeOne = async <T>(label: string, target: { close?: () => Promise<T>; quit?: () => Promise<T>; destroy?: () => Promise<T> } | null | undefined) => {
+      if (!target) return;
+      for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+          if (typeof (target as any).destroy === 'function') {
+            await (target as any).destroy();
+          } else if (typeof target.close === 'function') {
+            await target.close();
+          } else if (typeof target.quit === 'function') {
+            await target.quit();
+          }
+          return;
+        } catch (err) {
+          if (attempt === MAX_RETRIES) {
+            console.warn(`[TestHarness] failed to close ${label} after ${MAX_RETRIES} attempts:`, err);
+          } else {
+            await delay(RETRY_DELAY_MS);
+          }
+        }
+      }
+    };
+
+    await Promise.all([
+      closeOne('DataSource', this.dataSource),
+      closeOne('Redis', this.redisClient),
+      closeOne('App', this.app),
+    ]);
+  }
+
+  async withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    let lastError: Error | null = null;
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        return await fn();
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (attempt < MAX_RETRIES) await delay(RETRY_DELAY_MS);
+      }
     }
-    if (this.redisClient) {
-      await this.redisClient.quit();
-    }
-    if (this.app) {
-      await this.app.close();
-    }
+    throw lastError!;
   }
 }

--- a/apps/mobile/src/__tests__/use-auth.test.ts
+++ b/apps/mobile/src/__tests__/use-auth.test.ts
@@ -1,0 +1,81 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useAuth } from '../hooks/use-auth';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useAuth (mobile auth shell)', () => {
+  it('starts with no authenticated user', () => {
+    const { result } = renderHook(() => useAuth());
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it('recovers a stored session from localStorage', () => {
+    const stored = {
+      user: { id: '1', email: 'alice@test.com', role: 'USER' },
+      accessToken: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.test',
+    };
+    localStorage.setItem('mixmatch.auth', JSON.stringify(stored));
+
+    const { result } = renderHook(() => useAuth());
+    expect(result.current.user?.email).toBe('alice@test.com');
+    expect(result.current.accessToken).toBe(stored.accessToken);
+  });
+
+  it('clears a corrupted stored session', () => {
+    localStorage.setItem('mixmatch.auth', '{corrupted');
+
+    const { result } = renderHook(() => useAuth());
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it('setAuth persists and exposes the auth state', () => {
+    const { result } = renderHook(() => useAuth());
+
+    const auth: any = {
+      user: { id: '2', email: 'bob@test.com', role: 'USER' },
+      accessToken: 'token-abc',
+    };
+
+    act(() => result.current.setAuth(auth));
+    expect(result.current.user?.email).toBe('bob@test.com');
+    expect(result.current.accessToken).toBe('token-abc');
+  });
+
+  it('logout clears the auth state', () => {
+    const { result } = renderHook(() => useAuth());
+
+    act(() =>
+      result.current.setAuth({
+        user: { id: '3', email: 'carol@test.com', role: 'USER' },
+        accessToken: 'token-xyz',
+      }),
+    );
+    expect(result.current.user).not.toBeNull();
+
+    act(() => result.current.logout());
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it('handles setAuth when localStorage is full', () => {
+    const originalSetItem = Storage.prototype.setItem;
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementationOnce(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    const { result } = renderHook(() => useAuth());
+    act(() =>
+      result.current.setAuth({
+        user: { id: '4', email: 'dave@test.com', role: 'USER' },
+        accessToken: 'token-full',
+      }),
+    );
+
+    expect(result.current.user?.email).toBe('dave@test.com');
+    expect(result.current.accessToken).toBe('token-full');
+  });
+});

--- a/apps/mobile/src/hooks/use-auth.ts
+++ b/apps/mobile/src/hooks/use-auth.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const STORAGE_KEY = 'mixmatch.auth';
+
+export interface StoredAuth {
+  user: {
+    id: string;
+    email: string;
+    role: string;
+  };
+  accessToken: string;
+  refreshToken?: string;
+}
+
+export function useAuth() {
+  const [user, setUser] = useState<StoredAuth['user'] | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as StoredAuth;
+        if (parsed.user && parsed.accessToken) {
+          setUser(parsed.user);
+          setAccessToken(parsed.accessToken);
+        }
+      }
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+    setIsLoading(false);
+  }, []);
+
+  const setAuth = useCallback((auth: StoredAuth) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(auth));
+    } catch {
+      // storage full
+    }
+    setUser(auth.user);
+    setAccessToken(auth.accessToken);
+  }, []);
+
+  const logout = useCallback(() => {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // best effort
+    }
+    setUser(null);
+    setAccessToken(null);
+  }, []);
+
+  return { user, accessToken, isLoading, setAuth, logout };
+}

--- a/apps/web/src/__tests__/auth-context.test.tsx
+++ b/apps/web/src/__tests__/auth-context.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, act } from '@testing-library/react';
+import { AuthProvider, useAuth } from '../lib/auth-context';
+import { type ReactNode } from 'react';
+
+function TestConsumer() {
+  const auth = useAuth();
+  return (
+    <div>
+      <span data-testid="user">{auth.user?.email ?? 'null'}</span>
+      <span data-testid="token">{auth.accessToken ?? 'null'}</span>
+      <span data-testid="loading">{String(auth.isLoading)}</span>
+      <button data-testid="logout" onClick={auth.logout}>
+        Logout
+      </button>
+    </div>
+  );
+}
+
+function renderWithProvider(ui: ReactNode) {
+  return render(<AuthProvider>{ui}</AuthProvider>);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('AuthProvider (web auth shell edge cases)', () => {
+  it('recovers a valid stored session', () => {
+    const payload = btoa(JSON.stringify({ sub: '1', exp: Date.now() / 1000 + 3600 }));
+    const token = `header.${payload}.sig`;
+    localStorage.setItem(
+      'mixmatch.auth',
+      JSON.stringify({ user: { id: '1', email: 'alice@test.com', role: 'USER' }, accessToken: token }),
+    );
+
+    renderWithProvider(<TestConsumer />);
+    expect(screen.getByTestId('user').textContent).toBe('alice@test.com');
+  });
+
+  it('discards an expired token on load', () => {
+    const payload = btoa(JSON.stringify({ sub: '1', exp: Date.now() / 1000 - 3600 }));
+    const token = `header.${payload}.sig`;
+    localStorage.setItem(
+      'mixmatch.auth',
+      JSON.stringify({ user: { id: '1', email: 'alice@test.com', role: 'USER' }, accessToken: token }),
+    );
+
+    renderWithProvider(<TestConsumer />);
+    expect(screen.getByTestId('user').textContent).toBe('null');
+    expect(screen.getByTestId('token').textContent).toBe('null');
+  });
+
+  it('discards a malformed stored session', () => {
+    localStorage.setItem('mixmatch.auth', '{corrupted');
+    renderWithProvider(<TestConsumer />);
+    expect(screen.getByTestId('user').textContent).toBe('null');
+  });
+
+  it('discards stored session missing user field', () => {
+    localStorage.setItem('mixmatch.auth', JSON.stringify({ accessToken: 'abc' }));
+    renderWithProvider(<TestConsumer />);
+    expect(screen.getByTestId('user').textContent).toBe('null');
+  });
+
+  it('logout clears auth state', () => {
+    const payload = btoa(JSON.stringify({ sub: '1', exp: Date.now() / 1000 + 3600 }));
+    const token = `header.${payload}.sig`;
+    localStorage.setItem(
+      'mixmatch.auth',
+      JSON.stringify({ user: { id: '1', email: 'alice@test.com', role: 'USER' }, accessToken: token }),
+    );
+
+    renderWithProvider(<TestConsumer />);
+    expect(screen.getByTestId('user').textContent).toBe('alice@test.com');
+
+    act(() => screen.getByTestId('logout').click());
+    expect(screen.getByTestId('user').textContent).toBe('null');
+    expect(screen.getByTestId('token').textContent).toBe('null');
+  });
+});

--- a/apps/web/src/lib/auth-context.tsx
+++ b/apps/web/src/lib/auth-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { AuthUser } from '@mixmatch/shared';
-import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from 'react';
 
 const STORAGE_KEY = 'mixmatch.auth';
 
@@ -20,36 +20,68 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
+function isExpiredToken(token: string): boolean {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload.exp * 1000 < Date.now();
+  } catch {
+    return true;
+  }
+}
+
+function safelyParseStoredAuth(raw: string): StoredAuth | null {
+  try {
+    const parsed = JSON.parse(raw) as StoredAuth;
+    if (!parsed.user || !parsed.accessToken) return null;
+    if (typeof parsed.accessToken !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      try {
-        const stored = JSON.parse(raw) as StoredAuth;
-        setUser(stored.user);
-        setAccessToken(stored.accessToken);
-      } catch {
-        window.localStorage.removeItem(STORAGE_KEY);
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const stored = safelyParseStoredAuth(raw);
+        if (stored && !isExpiredToken(stored.accessToken)) {
+          setUser(stored.user);
+          setAccessToken(stored.accessToken);
+        } else {
+          window.localStorage.removeItem(STORAGE_KEY);
+        }
       }
+    } catch {
+      window.localStorage.removeItem(STORAGE_KEY);
     }
     setIsLoading(false);
   }, []);
 
-  const setAuth = (auth: StoredAuth) => {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(auth));
+  const setAuth = useCallback((auth: StoredAuth) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(auth));
+    } catch {
+      // storage full or unavailable — auth still works in memory
+    }
     setUser(auth.user);
     setAccessToken(auth.accessToken);
-  };
+  }, []);
 
-  const logout = () => {
-    window.localStorage.removeItem(STORAGE_KEY);
+  const logout = useCallback(() => {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // best effort
+    }
     setUser(null);
     setAccessToken(null);
-  };
+  }, []);
 
   return (
     <AuthContext.Provider value={{ user, accessToken, isLoading, setAuth, logout }}>


### PR DESCRIPTION
## Changes

### Token persistence — core flow (#604)
- Add `Session` model to Prisma schema with cascade-delete from User
- Implement `PrismaSessionStore` backed by PostgreSQL (replaces `InMemorySessionStore`)
- Wire `PrismaSessionStore` into auth routes for persistent token storage

### Web auth shell — edge cases (#561)
- Detect and discard expired tokens on app load
- Gracefully recover from malformed localStorage data
- Handle `localStorage.setItem` quota errors (auth continues in memory)

### Mobile auth shell — regression coverage (#565)
- Add `useAuth` hook for React Native with persistent storage
- Full test suite covering: initial state, recovery, corruption, setAuth, logout, and storage-full fallback

### Test harness — edge cases (#556)
- Add retry-with-backoff logic to harness cleanup operations
- Add defensive null/initialized guards in `DbTestUtils`
- Add `withRetry` utility for flaky async test setup

Closes #604
Closes #565
Closes #561
Closes #556