### PR TITLE
feat: me endpoint integration, shared types coverage, auth shell contracts

### DIFF
--- a/apps/web/src/__tests__/api-client.test.ts
+++ b/apps/web/src/__tests__/api-client.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { me } from '../lib/api-client';
+
+const API_URL = 'http://localhost:3001';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('api-client me()', () => {
+  it('calls GET /api/auth/me with the correct auth header', async () => {
+    const mockUser = { id: '1', email: 'alice@test.com', role: 'USER', createdAt: '', updatedAt: '' };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ user: mockUser }),
+    } as Response);
+
+    const result = await me('token-abc');
+    expect(result.email).toBe('alice@test.com');
+    expect(fetch).toHaveBeenCalledWith(`${API_URL}/api/auth/me`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer token-abc',
+      },
+    });
+  });
+
+  it('throws ApiError on non-ok response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: { message: 'Token expired' } }),
+    } as Response);
+
+    await expect(me('bad-token')).rejects.toThrow('Token expired');
+  });
+
+  it('throws ApiError on network failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(me('token-abc')).rejects.toThrow('Network error');
+  });
+});

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,4 +1,4 @@
-import type { AuthTokenResponse, LoginInput, RegisterInput } from '@mixmatch/shared';
+import type { AuthTokenResponse, AuthUser, LoginInput, RegisterInput } from '@mixmatch/shared';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
@@ -25,10 +25,33 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
   return data as T;
 }
 
+async function getJson<T>(path: string, token: string): Promise<T> {
+  const response = await fetch(`${API_URL}${path}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new ApiError(data?.error?.message ?? 'Something went wrong');
+  }
+
+  return data as T;
+}
+
 export function registerUser(input: RegisterInput): Promise<AuthTokenResponse> {
   return postJson<AuthTokenResponse>('/api/auth/register', input);
 }
 
 export function loginUser(input: LoginInput): Promise<AuthTokenResponse> {
   return postJson<AuthTokenResponse>('/api/auth/login', input);
+}
+
+export async function me(token: string): Promise<AuthUser> {
+  const result = await getJson<{ user: AuthUser }>('/api/auth/me', token);
+  return result.user;
 }

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -88,6 +88,42 @@ Workflows inject their own values at runtime — no `.env` files are committed.
 The postgres service in `regression-coverage.yml` uses database name
 `mixmatch_test` to avoid conflicts with other environments.
 
+## API endpoints
+
+### `/api/auth/me`
+
+Protected endpoint that returns the currently authenticated user's profile.
+
+```
+GET /api/auth/me
+Authorization: Bearer <access_token>
+```
+
+Response: `{ user: { id, email, role, createdAt, updatedAt } }`
+
+Error codes: `INVALID_TOKEN` (401), `TOKEN_EXPIRED` (401).
+
+### `/api/auth/refresh`
+
+Exchanges a valid refresh token for a new token pair (access + refresh).
+
+```
+POST /api/auth/refresh
+Content-Type: application/json
+
+{ "refreshToken": "<refresh_token>" }
+```
+
+Response: `{ accessToken, refreshToken }`
+
+### `/api/auth/register` & `/api/auth/login`
+
+Registration and login return `{ user: AuthUser, accessToken }`.
+
+## Web auth shell
+
+See [`docs/WEB-AUTH-SHELL.md`](./WEB-AUTH-SHELL.md) for the full scope and contracts.
+
 ## Secrets handling
 
 - Never commit `.env` files — they are gitignored.

--- a/docs/WEB-AUTH-SHELL.md
+++ b/docs/WEB-AUTH-SHELL.md
@@ -1,0 +1,76 @@
+# Web Auth Shell — Scope & Contracts
+
+## Purpose
+
+The web auth shell provides the authentication boundary for the Next.js web app. It handles user registration, login, session persistence, and protected route access.
+
+## Scope
+
+- **AuthProvider** — React context that wraps the app and exposes auth state.
+- **useAuth** — Hook that returns `{ user, accessToken, isLoading, setAuth, logout }`.
+- **AuthForm** — Reusable form component for email + password submission.
+- **api-client** — Functions for `/api/auth/register`, `/api/auth/login`, and `/api/auth/me`.
+
+## Contracts
+
+### AuthProvider
+
+```
+Input:  children: ReactNode
+State:  user: AuthUser | null
+        accessToken: string | null
+        isLoading: boolean
+Output: { user, accessToken, isLoading, setAuth, logout }
+```
+
+Storage: Persists `{ user, accessToken }` to `localStorage` under key `mixmatch.auth`.
+Recovery: On mount, reads stored value; discards if:
+- JSON parse fails
+- `user` or `accessToken` is missing
+- Token is expired (decoded JWT `exp` check)
+
+### AuthForm
+
+```
+Input:  title: string
+        submitLabel: string
+        onSubmit: (values: { email: string; password: string }) => Promise<void>
+        fieldErrors?: { email?: string; password?: string }
+Output: form submission event → calls onSubmit → shows error or succeeds
+```
+
+Validation: Email input has `type="email"` and `required`; password has `required`.
+Error handling: Server errors are caught and displayed as a general alert.
+
+### API Client
+
+```
+registerUser(input: RegisterInput) → Promise<AuthTokenResponse>
+loginUser(input: LoginInput)       → Promise<AuthTokenResponse>
+me(token: string)                  → Promise<AuthUser>
+```
+
+All functions:
+- Send `Content-Type: application/json`
+- Throw `ApiError` on non-ok responses
+- Use `NEXT_PUBLIC_API_URL` as base
+
+### State Machine
+
+```
+[Loading] → (stored session found & valid) → [Authenticated]
+[Loading] → (no stored session)            → [Unauthenticated]
+[Loading] → (stored session expired)       → [Unauthenticated] (storage cleared)
+[Authenticated] → logout()                 → [Unauthenticated]
+[Unauthenticated] → setAuth(response)      → [Authenticated]
+```
+
+## Edge Cases
+
+| Situation | Behaviour |
+|-----------|-----------|
+| Expired token on load | Cleared from localStorage, user sees login |
+| Corrupted localStorage | `JSON.parse` fails → removed, user sees login |
+| `localStorage.setItem` quota exceeded | Auth continues in memory (lost on refresh) |
+| Network failure on login | ApiError message shown in form |
+| Token missing from storage | Treated as unauthenticated |

--- a/packages/shared/src/__tests__/auth-errors.test.ts
+++ b/packages/shared/src/__tests__/auth-errors.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { AuthErrorCode } from '../types/auth-errors.js';
+
+describe('AuthErrorCode enum', () => {
+  it('has the expected error codes', () => {
+    expect(AuthErrorCode.INVALID_TOKEN).toBe('INVALID_TOKEN');
+    expect(AuthErrorCode.TOKEN_EXPIRED).toBe('TOKEN_EXPIRED');
+    expect(AuthErrorCode.SESSION_EXPIRED).toBe('SESSION_EXPIRED');
+    expect(AuthErrorCode.INSUFFICIENT_PERMISSIONS).toBe('INSUFFICIENT_PERMISSIONS');
+    expect(AuthErrorCode.FORBIDDEN).toBe('FORBIDDEN');
+    expect(AuthErrorCode.ACCOUNT_LOCKED).toBe('ACCOUNT_LOCKED');
+    expect(AuthErrorCode.RATE_LIMITED).toBe('RATE_LIMITED');
+    expect(AuthErrorCode.SESSION_NOT_FOUND).toBe('SESSION_NOT_FOUND');
+    expect(AuthErrorCode.INVALID_REFRESH_TOKEN).toBe('INVALID_REFRESH_TOKEN');
+  });
+
+  it('all error codes are unique', () => {
+    const values = Object.values(AuthErrorCode);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe('AuthErrorResponse contract', () => {
+  it('conforms to the expected shape', () => {
+    const error: any = {
+      code: AuthErrorCode.INVALID_TOKEN,
+      message: 'Token is invalid',
+    };
+    expect(error.code).toBeDefined();
+    expect(error.message).toBeDefined();
+  });
+
+  it('supports optional retryAfter field', () => {
+    const rateLimited: any = {
+      code: AuthErrorCode.RATE_LIMITED,
+      message: 'Too many requests',
+      retryAfter: 60,
+    };
+    expect(rateLimited.retryAfter).toBe(60);
+  });
+});

--- a/packages/shared/src/__tests__/session-types.test.ts
+++ b/packages/shared/src/__tests__/session-types.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { Session, SessionConfig, TokenPair } from '../types/session.js';
+
+describe('Session interface contract', () => {
+  it('conforms to the expected shape', () => {
+    const session: Session = {
+      id: 'uuid-1',
+      userId: 'user-1',
+      refreshToken: 'rt-1',
+      expiresAt: '2025-12-31T00:00:00.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+    };
+    expect(session.id).toBeDefined();
+    expect(session.userId).toBeDefined();
+    expect(session.refreshToken).toBeDefined();
+    expect(session.expiresAt).toBeDefined();
+    expect(session.createdAt).toBeDefined();
+  });
+});
+
+describe('TokenPair interface contract', () => {
+  it('holds an access token and a refresh token', () => {
+    const pair: TokenPair = { accessToken: 'at-1', refreshToken: 'rt-1' };
+    expect(pair.accessToken).toBe('at-1');
+    expect(pair.refreshToken).toBe('rt-1');
+  });
+});
+
+describe('SessionConfig interface contract', () => {
+  it('holds refresh token expiry and max active sessions', () => {
+    const config: SessionConfig = {
+      refreshTokenExpiryMs: 7 * 24 * 60 * 60 * 1000,
+      maxActiveSessions: 5,
+    };
+    expect(config.refreshTokenExpiryMs).toBe(604800000);
+    expect(config.maxActiveSessions).toBe(5);
+  });
+});

--- a/packages/shared/src/__tests__/session.schema.test.ts
+++ b/packages/shared/src/__tests__/session.schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { refreshTokenSchema, updateProfileSchema } from '../validation/session.schema.js';
+
+describe('refreshTokenSchema', () => {
+  it('accepts a valid refresh token', () => {
+    const result = refreshTokenSchema.safeParse({ refreshToken: 'abc-123' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty refresh token', () => {
+    const result = refreshTokenSchema.safeParse({ refreshToken: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a missing refresh token', () => {
+    const result = refreshTokenSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateProfileSchema', () => {
+  it('accepts a valid email update', () => {
+    const result = updateProfileSchema.safeParse({ email: 'new@example.com' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid name update', () => {
+    const result = updateProfileSchema.safeParse({ name: 'Alice' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an empty body (partial update)', () => {
+    const result = updateProfileSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid email', () => {
+    const result = updateProfileSchema.safeParse({ email: 'not-email' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a name that is too long', () => {
+    const result = updateProfileSchema.safeParse({ name: 'A'.repeat(101) });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Changes

### Me endpoint — core flow (#599)
- Add `me(token)` function to the web api-client
- Add `getJson` helper for authenticated GET requests
- Add full test coverage for me() (correct headers, error handling, network failure)

### Shared types — regression coverage (#570)
- Add tests for `refreshTokenSchema` and `updateProfileSchema` (empty, missing, invalid inputs)
- Add tests for `AuthErrorCode` enum (all values present, uniqueness)
- Add tests for `Session`, `TokenPair`, and `SessionConfig` interface contracts

### Web auth shell — scope and contracts (#558)
- Add `docs/WEB-AUTH-SHELL.md` defining: provider contract, form contract, API client contract, state machine, edge case table

### Environment docs — core flow (#579)
- Enhance ENVIRONMENT.md with me endpoint and refresh endpoint documentation
- Cross-reference WEB-AUTH-SHELL.md

Closes #599
Closes #579
Closes #570
Closes #558