### PR TITLE
feat(me-endpoint, token-persistence): harden edge cases, define contracts, and add regression coverage — Sprint 1

### DIFF
--- a/apps/api/src/modules/auth/tests/me-hardening.test.ts
+++ b/apps/api/src/modules/auth/tests/me-hardening.test.ts
@@ -1,0 +1,92 @@
+import jwt from "jsonwebtoken";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createTestApp } from "./test-app.js";
+
+const JWT_SECRET =
+  process.env.JWT_SECRET ?? "dev-secret-change-me-abcdefghijklmnopqrstuvwxyz123";
+
+/**
+ * Hardened edge-case tests for GET /api/auth/me.
+ * Covers failure modes not already addressed in me.test.ts.
+ *
+ * Track: me endpoint  |  Sprint 1  |  issue #776 (harden edge cases)
+ */
+describe("GET /api/auth/me — hardened edge cases", () => {
+  it("returns 401 when Authorization header is present but value is empty string", async () => {
+    const app = createTestApp();
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", "");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("INVALID_TOKEN");
+  });
+
+  it("returns 401 when Bearer token is only whitespace", async () => {
+    const app = createTestApp();
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", "Bearer    ");
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("INVALID_TOKEN");
+  });
+
+  it("returns 401 when token is signed with a different secret", async () => {
+    const app = createTestApp();
+    const token = jwt.sign({ sub: "user-id" }, "wrong-secret-that-is-long-enough");
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("INVALID_TOKEN");
+  });
+
+  it("returns 401 when token algorithm is none (alg:none attack)", async () => {
+    const app = createTestApp();
+    // Craft a token with alg:none — should be rejected
+    const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ sub: "user-id", exp: 9999999999 })).toString("base64url");
+    const noneToken = `${header}.${payload}.`;
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", `Bearer ${noneToken}`);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("INVALID_TOKEN");
+  });
+
+  it("returns 401 when token has no sub claim", async () => {
+    const app = createTestApp();
+    const token = jwt.sign({ role: "USER" }, JWT_SECRET); // no sub
+    const res = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("INVALID_TOKEN");
+  });
+
+  it("does not expose passwordHash or internal fields in the response", async () => {
+    const app = createTestApp();
+    const credentials = { email: "me-harden@example.com", password: "password123" };
+    const regRes = await request(app).post("/api/auth/register").send(credentials);
+    const { accessToken } = regRes.body;
+
+    const meRes = await request(app)
+      .get("/api/auth/me")
+      .set("Authorization", `Bearer ${accessToken}`);
+
+    expect(meRes.status).toBe(200);
+    const user = meRes.body.user;
+    expect(user.passwordHash).toBeUndefined();
+    expect(user.password).toBeUndefined();
+    // Only safe fields exposed
+    expect(user.email).toBe(credentials.email);
+    expect(user.id).toBeDefined();
+    expect(user.role).toBeDefined();
+  });
+
+  it("responds with correct Content-Type (application/json)", async () => {
+    const app = createTestApp();
+    const res = await request(app).get("/api/auth/me");
+    expect(res.headers["content-type"]).toMatch(/application\/json/);
+  });
+});

--- a/packages/shared/src/__tests__/token-persistence.regression.test.ts
+++ b/packages/shared/src/__tests__/token-persistence.regression.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { parsePersistedAuth, PERSISTED_AUTH_KEY } from "@mixmatch/shared";
+
+/**
+ * Regression coverage for the token-persistence workstream.
+ *
+ * Track: token persistence  |  Sprint 1  |  issue #780 (regression coverage)
+ *
+ * These tests verify the parsePersistedAuth contract defined in
+ * packages/shared/src/types/token-persistence.ts. They run without
+ * any browser or API dependency.
+ */
+describe("parsePersistedAuth — regression coverage", () => {
+  it("returns { status: empty } for null input", () => {
+    expect(parsePersistedAuth(null)).toEqual({ status: "empty" });
+  });
+
+  it("returns { status: corrupt } for non-JSON string", () => {
+    const result = parsePersistedAuth("not-json");
+    expect(result.status).toBe("corrupt");
+  });
+
+  it("returns { status: corrupt } for JSON missing accessToken", () => {
+    const raw = JSON.stringify({ user: { id: "1", email: "a@b.com" } });
+    const result = parsePersistedAuth(raw);
+    expect(result.status).toBe("corrupt");
+  });
+
+  it("returns { status: corrupt } for JSON missing user", () => {
+    const raw = JSON.stringify({ accessToken: "tok" });
+    const result = parsePersistedAuth(raw);
+    expect(result.status).toBe("corrupt");
+  });
+
+  it("returns { status: corrupt } when accessToken is not a string", () => {
+    const raw = JSON.stringify({ user: { id: "1" }, accessToken: 42 });
+    const result = parsePersistedAuth(raw);
+    expect(result.status).toBe("corrupt");
+  });
+
+  it("returns { status: restored } for a valid persisted state", () => {
+    const state = {
+      user: { id: "u1", email: "test@example.com", role: "USER", createdAt: "", updatedAt: "" },
+      accessToken: "valid.jwt.token",
+    };
+    const result = parsePersistedAuth(JSON.stringify(state));
+    expect(result.status).toBe("restored");
+    if (result.status === "restored") {
+      expect(result.state.accessToken).toBe("valid.jwt.token");
+      expect(result.state.user.email).toBe("test@example.com");
+    }
+  });
+
+  it("storage key is the literal string mixmatch.auth", () => {
+    expect(PERSISTED_AUTH_KEY).toBe("mixmatch.auth");
+  });
+
+  it("returns { status: corrupt } for an empty JSON object", () => {
+    const result = parsePersistedAuth("{}");
+    expect(result.status).toBe("corrupt");
+  });
+
+  it("returns { status: corrupt } for a JSON array", () => {
+    const result = parsePersistedAuth("[]");
+    expect(result.status).toBe("corrupt");
+  });
+});

--- a/packages/shared/src/types/token-persistence.ts
+++ b/packages/shared/src/types/token-persistence.ts
@@ -1,0 +1,82 @@
+/**
+ * Token Persistence — Scope & Contracts
+ *
+ * Track: token persistence | me endpoint  |  Sprint 1
+ *
+ * Defines the TypeScript interfaces that describe how authentication
+ * tokens are persisted on the client, hydrated on page load, and
+ * validated against the server via GET /api/auth/me.
+ */
+
+import type { AuthUser } from "./auth.js";
+
+// ---------------------------------------------------------------------------
+// Storage contract
+// ---------------------------------------------------------------------------
+
+/** The shape written to / read from localStorage under "mixmatch.auth". */
+export interface PersistedAuthState {
+  user: AuthUser;
+  accessToken: string;
+}
+
+/** Storage key used by AuthProvider. Must never change without a migration. */
+export const PERSISTED_AUTH_KEY = "mixmatch.auth" as const;
+
+// ---------------------------------------------------------------------------
+// Hydration contract
+// ---------------------------------------------------------------------------
+
+/** Result returned by AuthProvider after attempting to rehydrate from storage. */
+export type HydrationResult =
+  | { status: "restored"; state: PersistedAuthState }
+  | { status: "empty" }
+  | { status: "corrupt"; reason: string };
+
+/**
+ * Attempts to parse a raw localStorage value into `PersistedAuthState`.
+ * Returns a discriminated union so callers handle every case explicitly.
+ */
+export function parsePersistedAuth(raw: string | null): HydrationResult {
+  if (raw === null) return { status: "empty" };
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed \!== null &&
+      "user" in parsed &&
+      "accessToken" in parsed &&
+      typeof (parsed as Record<string, unknown>).accessToken === "string"
+    ) {
+      return { status: "restored", state: parsed as PersistedAuthState };
+    }
+    return { status: "corrupt", reason: "missing required fields" };
+  } catch {
+    return { status: "corrupt", reason: "invalid JSON" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Me-endpoint integration contract
+// ---------------------------------------------------------------------------
+
+/** Error codes returned by GET /api/auth/me */
+export type MeEndpointErrorCode =
+  | "INVALID_TOKEN"
+  | "TOKEN_EXPIRED"
+  | "NOT_FOUND";
+
+/**
+ * Edge cases that must be handled when rehydrating from storage and
+ * validating the persisted token against the server:
+ *
+ * | Scenario                   | Expected behaviour                          |
+ * |----------------------------|---------------------------------------------|
+ * | localStorage empty         | Treat as logged-out; no /me call            |
+ * | localStorage corrupt JSON  | Remove key; treat as logged-out             |
+ * | /me returns 401            | Clear storage; redirect to /login           |
+ * | /me returns 404            | Clear storage; redirect to /login           |
+ * | /me returns 200            | Restore session; update user from response  |
+ * | Multiple tabs              | Each tab hydrates independently             |
+ */
+export type TokenPersistenceEdgeCases = true; // marker — see apps/docs/token-persistence.md


### PR DESCRIPTION
## Summary

Implements the **me endpoint** and **token persistence** workstreams for Sprint 1, scoped to the current auth-first monorepo.

### Changes

#### `packages/shared/src/types/token-persistence.ts` _(new)_
TypeScript contracts for the token persistence workstream:
- `PersistedAuthState` — the exact shape stored in `localStorage` under `mixmatch.auth`
- `PERSISTED_AUTH_KEY` — the storage key as a typed const (prevents future typos)
- `HydrationResult` — discriminated union covering `restored | empty | corrupt` so callers handle every case
- `parsePersistedAuth()` — pure utility that parses a raw localStorage value; no browser dependency needed for testing
- `MeEndpointErrorCode` — union of the three error codes returned by `GET /api/auth/me`
- Inline edge-case table documenting expected behaviour for every failure scenario

#### `packages/shared/src/__tests__/token-persistence.regression.test.ts` _(new)_
9 regression tests for `parsePersistedAuth`:
- `null` → `empty`
- Invalid JSON, missing fields, wrong field types → `corrupt` (with reason)
- Valid state → `restored` with correct shape
- Storage key constant equals `"mixmatch.auth"`

#### `apps/api/src/modules/auth/tests/me-hardening.test.ts` _(new)_
6 additional edge-case tests for `GET /api/auth/me`, extending `me.test.ts`:
- Empty `Authorization` value → 401 `INVALID_TOKEN`
- Whitespace-only Bearer token → 401 `INVALID_TOKEN`
- Token signed with wrong secret → 401 `INVALID_TOKEN`
- `alg:none` attack token → 401 `INVALID_TOKEN`
- Token without `sub` claim → 401 `INVALID_TOKEN`
- Response must not expose `passwordHash` or raw `password`

### Acceptance Criteria met

- [x] Scoped to current repo architecture (no future systems assumed)
- [x] Reflects the auth-first foundation (token validation, /me endpoint)
- [x] Output is small enough to land as one independently reviewable PR

### Related Issues

Closes #776
Closes #777
Closes #778
Closes #780