### PR TITLE
docs: define scope and contracts for me endpoint, health checks, auth errors, and web auth shell

### DIFF
--- a/apps/docs/auth-errors.md
+++ b/apps/docs/auth-errors.md
@@ -1,5 +1,22 @@
 # Auth Error Handling
 
+## Scope
+
+The auth error system defines how authentication and authorization failures are
+communicated from the API to clients. It establishes a consistent error shape,
+a machine-readable error code vocabulary, and a mapping from error classes to
+HTTP status codes so that clients can handle failures uniformly without parsing
+human-readable messages.
+
+## Why this contract matters
+
+Without a shared error contract, each endpoint could invent its own error shape,
+leaving clients to guess at status codes and message formats. The auth error
+contract ensures that every authentication failure — expired token, missing
+credential, locked account, rate limit — follows the same JSON structure and
+uses the same error code enum. This makes client-side error handling reliable
+and testable.
+
 ## Strategy
 
 The API uses a consistent error response format across all endpoints. Every error

--- a/apps/docs/health-checks.md
+++ b/apps/docs/health-checks.md
@@ -1,0 +1,93 @@
+# Health Checks
+
+## Scope
+
+The health check endpoint provides a lightweight, unauthenticated liveness probe
+for load balancers, container orchestrators, and monitoring systems. It confirms
+the API process is running and able to accept HTTP requests.
+
+## Contract
+
+### Request
+
+```
+GET /health
+```
+
+No authentication required. No request body.
+
+### Success Response
+
+```
+HTTP 200
+{
+  "status": "ok"
+}
+```
+
+### Error Responses
+
+The health endpoint is designed to be maximally available. It does not perform
+database connectivity checks, external service pings, or dependency validation.
+A 200 response confirms only that the Express process is running.
+
+| Status | Condition |
+|--------|-----------|
+| 200    | API process is alive and accepting requests |
+
+## TypeScript Contract
+
+```typescript
+interface HealthResponse {
+  status: 'ok';
+}
+```
+
+## Architecture
+
+```
+Client                          Express API
+  │                                  │
+  │  GET /health                     │
+  │ ───────────────────────────────► │
+  │                                  │
+  │  200 { status: 'ok' }           │
+  │ ◄─────────────────────────────── │
+```
+
+The health route is mounted directly on the Express app before any middleware
+that might fail (auth, rate limiting, error handling). This ensures the probe
+always reaches a handler as long as the process is alive.
+
+## Integration Points
+
+| Component | Role |
+|-----------|------|
+| `apps/api/src/app.ts` | Mounts `GET /health` route |
+| Load balancer / k8s | Polls `/health` for liveness |
+| Monitoring | Alerts on non-200 responses |
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Database is down | 200 (health check does not verify DB) |
+| JWT_SECRET not set | 200 (health check does not verify auth config) |
+| All other routes fail | 200 (health check is independent of error middleware) |
+| Request includes auth header | 200 (auth is not validated on this route) |
+| HEAD request | Express serves GET handler for HEAD automatically |
+
+## Testing
+
+See `apps/api/src/health.test.ts` — verifies 200 response with `{ status: 'ok' }` body.
+
+## Design Decisions
+
+- **No dependency checks**: The health endpoint intentionally avoids checking
+  database connectivity, external APIs, or message queues. This keeps it fast
+  and prevents cascading failures where a DB outage also takes down the
+  liveness probe.
+- **Minimal response**: The `{ status: 'ok' }` shape is standard for
+  Kubernetes liveness/readiness probes and load balancer health checks.
+- **Error middleware not involved**: The route is registered before the error
+  middleware, so it cannot be affected by error-handling bugs.

--- a/apps/docs/me-endpoint.md
+++ b/apps/docs/me-endpoint.md
@@ -1,5 +1,21 @@
 # Me Endpoint
 
+## Scope
+
+The `/me` endpoint is the primary session validation mechanism. It verifies that
+a bearer token is still valid and returns the authenticated user's profile. It
+is the foundation for all client-side session restoration after page reload.
+
+## Why this endpoint matters
+
+Every authenticated client (web, mobile, future apps) needs a way to check
+whether a previously stored token is still usable. Rather than trusting local
+state alone, the client calls `/me` on app load to confirm the session with the
+server. This catches token revocation, user deletion, and credential rotation
+that local state cannot detect.
+
+---
+
 **Route:** `GET /api/auth/me`
 **Auth:** Required (Bearer token)
 

--- a/apps/docs/web-auth-shell.md
+++ b/apps/docs/web-auth-shell.md
@@ -4,6 +4,10 @@
 
 The web auth shell is the client-side authentication boundary for the Next.js web app. It wraps all authenticated pages and provides a consistent auth context to the component tree.
 
+## Why this boundary exists
+
+Authentication touches multiple concerns: API calls, state management, token storage, error handling, and page routing. Without a single shell, each page would duplicate this logic and risk inconsistent behavior. The auth shell centralises all of these concerns so that individual pages only need to consume `useAuth()` and render their content.
+
 ## Boundaries
 
 ### What the shell owns


### PR DESCRIPTION
## Summary

This PR defines scope and contracts for four Sprint 1 platform foundation workstreams, tightening the auth-first monorepo so the team can build quickly without breaking the base workflow.

### Changes

**New file: `apps/docs/health-checks.md`** — Defines the scope, contract, architecture, edge cases, and design decisions for the `/health` liveness probe endpoint. Documents why the endpoint intentionally avoids dependency checks and how it integrates with load balancers and monitoring.

**Enhanced: `apps/docs/me-endpoint.md`** — Added a dedicated scope section explaining why the `/me` endpoint exists as the primary session validation mechanism, how it serves as the foundation for client-side session restoration, and what problems it solves that local state alone cannot.

**Enhanced: `apps/docs/web-auth-shell.md`** — Added a "Why this boundary exists" section documenting the rationale behind centralising authentication concerns (API calls, state management, token storage, error handling, page routing) into a single shell to prevent duplication and inconsistent behavior.

**Enhanced: `apps/docs/auth-errors.md`** — Added scope section defining the auth error system's purpose: establishing a consistent error shape, machine-readable error code vocabulary, and HTTP status code mapping so clients can handle failures uniformly without parsing human-readable messages.

### Backlog Keys

- S1-091 (me endpoint: define scope and contracts)
- S1-036 (health checks: define scope and contracts)
- S1-011 (auth errors: define scope and contracts)
- S1-055 (web auth shell: integrate and document)

Closes #773
Closes #718
Closes #693
Closes #737