### PR TITLE
test: add regression coverage for route protection, validation contracts, and session lifecycle

### DIFF
--- a/apps/api/src/modules/auth/tests/route-protection.test.ts
+++ b/apps/api/src/modules/auth/tests/route-protection.test.ts
@@ -1,0 +1,236 @@
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import { createTestApp } from './test-app.js';
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-secret-change-me-abcdefghijklmnopqrstuvwxyz123';
+
+describe('Route protection — regression coverage', () => {
+  describe('public routes', () => {
+    it('register does not require authentication', async () => {
+      const app = createTestApp();
+      const res = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'public@test.com', password: 'password123' });
+
+      expect(res.status).toBe(201);
+    });
+
+    it('login does not require authentication', async () => {
+      const app = createTestApp();
+      await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'login-test@test.com', password: 'password123' });
+
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({ email: 'login-test@test.com', password: 'password123' });
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('authenticated routes', () => {
+    it('rejects request without Authorization header', async () => {
+      const app = createTestApp();
+      const res = await request(app).get('/api/auth/me');
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('INVALID_TOKEN');
+    });
+
+    it('rejects request with malformed Authorization header', async () => {
+      const app = createTestApp();
+      const res = await request(app)
+        .get('/api/auth/me')
+        .set('Authorization', 'NotBearer token');
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('INVALID_TOKEN');
+    });
+
+    it('rejects request with empty Bearer token', async () => {
+      const app = createTestApp();
+      const res = await request(app)
+        .get('/api/auth/me')
+        .set('Authorization', 'Bearer ');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects request with expired token', async () => {
+      const app = createTestApp();
+      const expiredToken = jwt.sign(
+        { sub: 'user-1', role: 'USER' },
+        JWT_SECRET,
+        { expiresIn: '-1h' },
+      );
+
+      const res = await request(app)
+        .get('/api/auth/me')
+        .set('Authorization', `Bearer ${expiredToken}`);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('TOKEN_EXPIRED');
+    });
+
+    it('rejects request with token signed by wrong secret', async () => {
+      const app = createTestApp();
+      const wrongSecretToken = jwt.sign(
+        { sub: 'user-1', role: 'USER' },
+        'completely-wrong-secret-key-1234567890',
+        { expiresIn: '1h' },
+      );
+
+      const res = await request(app)
+        .get('/api/auth/me')
+        .set('Authorization', `Bearer ${wrongSecretToken}`);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('INVALID_TOKEN');
+    });
+
+    it('allows request with valid token', async () => {
+      const app = createTestApp();
+      const registerRes = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'valid@test.com', password: 'password123' });
+
+      const res = await request(app)
+        .get('/api/auth/me')
+        .set('Authorization', `Bearer ${registerRes.body.accessToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.user.email).toBe('valid@test.com');
+    });
+  });
+
+  describe('role-based routes', () => {
+    it('rejects USER role on ADMIN route', async () => {
+      const app = createTestApp();
+      const registerRes = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'user-role@test.com', password: 'password123' });
+
+      const res = await request(app)
+        .get('/api/auth/admin')
+        .set('Authorization', `Bearer ${registerRes.body.accessToken}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('INSUFFICIENT_PERMISSIONS');
+    });
+
+    it('allows ADMIN role on ADMIN route', async () => {
+      const app = createTestApp();
+      const registerRes = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'admin-role@test.com', password: 'password123' });
+
+      const adminToken = jwt.sign(
+        { sub: registerRes.body.user.id, role: 'ADMIN' },
+        JWT_SECRET,
+        { expiresIn: '1h' },
+      );
+
+      const res = await request(app)
+        .get('/api/auth/admin')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects expired token on ADMIN route', async () => {
+      const app = createTestApp();
+      const expiredAdminToken = jwt.sign(
+        { sub: 'admin-1', role: 'ADMIN' },
+        JWT_SECRET,
+        { expiresIn: '-1h' },
+      );
+
+      const res = await request(app)
+        .get('/api/auth/admin')
+        .set('Authorization', `Bearer ${expiredAdminToken}`);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error.code).toBe('TOKEN_EXPIRED');
+    });
+  });
+
+  describe('ownership-based routes', () => {
+    it('allows user to update their own profile', async () => {
+      const app = createTestApp();
+      const registerRes = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'owner@test.com', password: 'password123' });
+
+      const res = await request(app)
+        .put(`/api/auth/profile/${registerRes.body.user.id}`)
+        .set('Authorization', `Bearer ${registerRes.body.accessToken}`)
+        .send({ email: 'updated@test.com' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.user.email).toBe('updated@test.com');
+    });
+
+    it('rejects cross-user profile update', async () => {
+      const app = createTestApp();
+      const userA = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'user-a@test.com', password: 'password123' });
+      const userB = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'user-b@test.com', password: 'password123' });
+
+      const res = await request(app)
+        .put(`/api/auth/profile/${userB.body.user.id}`)
+        .set('Authorization', `Bearer ${userA.body.accessToken}`)
+        .send({ email: 'hacked@test.com' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.error.code).toBe('INSUFFICIENT_PERMISSIONS');
+    });
+
+    it('rejects ownership check when params.id is missing', async () => {
+      const app = createTestApp();
+      const registerRes = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'no-params@test.com', password: 'password123' });
+
+      const res = await request(app)
+        .get('/api/auth/ownership-test')
+        .set('Authorization', `Bearer ${registerRes.body.accessToken}`);
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('error response consistency', () => {
+    it('returns consistent error shape for all 401 responses', async () => {
+      const app = createTestApp();
+      const res = await request(app).get('/api/auth/me');
+
+      expect(res.status).toBe(401);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error).toHaveProperty('code');
+      expect(res.body.error).toHaveProperty('message');
+      expect(typeof res.body.error.code).toBe('string');
+      expect(typeof res.body.error.message).toBe('string');
+    });
+
+    it('returns consistent error shape for all 403 responses', async () => {
+      const app = createTestApp();
+      const registerRes = await request(app)
+        .post('/api/auth/register')
+        .send({ email: 'error-shape@test.com', password: 'password123' });
+
+      const res = await request(app)
+        .get('/api/auth/admin')
+        .set('Authorization', `Bearer ${registerRes.body.accessToken}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error).toHaveProperty('code');
+      expect(res.body.error).toHaveProperty('message');
+    });
+  });
+});

--- a/apps/docs/session-lifecycle.md
+++ b/apps/docs/session-lifecycle.md
@@ -1,5 +1,19 @@
 # Session Lifecycle
 
+## Scope
+
+The session lifecycle defines how user authentication state is created, maintained,
+refreshed, and destroyed across the API and its clients. It covers token issuance,
+token validation, session refresh, session revocation, and the constraints that
+govern concurrent sessions.
+
+## Why this contract matters
+
+Without a clear session lifecycle, clients cannot reliably determine when a user
+is logged in, when a token needs refreshing, or how to handle session expiry.
+The lifecycle contract ensures that every client — web, mobile, future apps —
+follows the same token flow and handles edge cases consistently.
+
 ## Token Issuance
 
 When a user registers or logs in, the API issues a short-lived **access token**
@@ -25,8 +39,9 @@ Body: { refreshToken: "<opaque-uuid>" }
 ```
 
 The server validates the refresh token against its in-memory store, checks
-expiry, and returns a fresh access token. The refresh token itself is **not**
-rotated (simplification for v1).
+expiry, and returns a fresh access token. The old refresh token is deleted and
+a new one is issued (rotation). This ensures that a leaked refresh token cannot
+be reused indefinitely.
 
 ## Session Expiry
 
@@ -37,6 +52,18 @@ rotated (simplification for v1).
 
 A session is considered expired when its refresh token has passed the 7-day
 window. Expired refresh tokens are pruned on read and via periodic cleanup.
+
+## Concurrent Session Limits
+
+Each user is limited to a maximum of 5 active sessions. When the limit is
+reached, new session creation is rejected with `401 INVALID_REFRESH_TOKEN`.
+Existing sessions can be revoked to free up slots.
+
+| Constraint | Value |
+|------------|-------|
+| Max concurrent sessions per user | 5 |
+| Refresh token TTL | 7 days |
+| Access token TTL | 1 hour (configurable via `JWT_EXPIRES_IN`) |
 
 ## How `requireAuth` Validates Tokens
 
@@ -62,6 +89,29 @@ These guards are applied as Express middlewares before the route handler.
 router.put('/profile/:id', requireAuth, allowOwnership, handler);
 router.get('/admin', requireAuth, requireRole(UserRole.ADMIN), handler);
 ```
+
+## Integration Points
+
+| Component | Role |
+|-----------|------|
+| `session.service.ts` | Creates, refreshes, and revokes sessions |
+| `session.store.ts` | Persists sessions (InMemory for tests, Prisma for production) |
+| `session.types.ts` | Defines Session, TokenPair, SESSION_CONFIG |
+| `auth.service.ts` | Orchestrates registration/login with session creation |
+| `auth.middleware.ts` | Validates access tokens via JWT verification |
+| `auth.guard.ts` | Composes role/ownership checks on top of requireAuth |
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Refresh token reused after rotation | 401 INVALID_REFRESH_TOKEN (old token deleted) |
+| Refresh token expired | 401 INVALID_REFRESH_TOKEN, session deleted |
+| Max sessions reached | 401 INVALID_REFRESH_TOKEN with "Maximum active sessions reached" |
+| Revoke session that doesn't exist | 401 INVALID_REFRESH_TOKEN |
+| Revoke all sessions for a user | All sessions deleted, other users unaffected |
+| Access token expired but refresh valid | Client calls /refresh to get new access token |
+| Both tokens expired | User must re-authenticate (login again) |
 
 ## Troubleshooting
 

--- a/packages/shared/src/__tests__/auth.schema.test.ts
+++ b/packages/shared/src/__tests__/auth.schema.test.ts
@@ -130,3 +130,123 @@ describe('loginSchema', () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe('registerSchema — regression coverage', () => {
+  it('rejects extra fields (strict mode)', () => {
+    const result = registerSchema.safeParse({
+      email: 'user@example.com',
+      password: 'password123',
+      extraField: 'should not be here',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('normalizes email to lowercase', () => {
+    const result = registerSchema.safeParse({
+      email: 'USER@EXAMPLE.COM',
+      password: 'password123',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.email).toBe('user@example.com');
+    }
+  });
+
+  it('trims whitespace from email', () => {
+    const result = registerSchema.safeParse({
+      email: '  user@example.com  ',
+      password: 'password123',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.email).toBe('user@example.com');
+    }
+  });
+
+  it('rejects email with no domain', () => {
+    const result = registerSchema.safeParse({
+      email: 'user@',
+      password: 'password123',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects email with no local part', () => {
+    const result = registerSchema.safeParse({
+      email: '@example.com',
+      password: 'password123',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects completely empty object', () => {
+    const result = registerSchema.safeParse({});
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects null input', () => {
+    const result = registerSchema.safeParse(null);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts password at boundary of 8 characters', () => {
+    const result = registerSchema.safeParse({
+      email: 'user@example.com',
+      password: '12345678',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects password at 7 characters', () => {
+    const result = registerSchema.safeParse({
+      email: 'user@example.com',
+      password: '1234567',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('loginSchema — regression coverage', () => {
+  it('rejects extra fields (strict mode)', () => {
+    const result = loginSchema.safeParse({
+      email: 'user@example.com',
+      password: 'password123',
+      rememberMe: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('normalizes email to lowercase', () => {
+    const result = loginSchema.safeParse({
+      email: 'USER@EXAMPLE.COM',
+      password: 'password123',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.email).toBe('user@example.com');
+    }
+  });
+
+  it('rejects completely empty object', () => {
+    const result = loginSchema.safeParse({});
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects null input', () => {
+    const result = loginSchema.safeParse(null);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/__tests__/session.schema.test.ts
+++ b/packages/shared/src/__tests__/session.schema.test.ts
@@ -86,3 +86,83 @@ describe('updateProfileSchema', () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe('refreshTokenSchema — regression coverage', () => {
+  it('accepts a long UUID-style token', () => {
+    const result = refreshTokenSchema.safeParse({
+      refreshToken: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a token exceeding max length', () => {
+    const result = refreshTokenSchema.safeParse({
+      refreshToken: 'x'.repeat(1025),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a token at exactly max length', () => {
+    const result = refreshTokenSchema.safeParse({
+      refreshToken: 'x'.repeat(1024),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects undefined refresh token', () => {
+    const result = refreshTokenSchema.safeParse({ refreshToken: undefined });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a boolean refresh token', () => {
+    const result = refreshTokenSchema.safeParse({ refreshToken: true });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an array refresh token', () => {
+    const result = refreshTokenSchema.safeParse({ refreshToken: ['token'] });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateProfileSchema — regression coverage', () => {
+  it('accepts a name at exactly 100 characters', () => {
+    const result = updateProfileSchema.safeParse({ name: 'a'.repeat(100) });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects extra fields (strict mode)', () => {
+    const result = updateProfileSchema.safeParse({
+      email: 'user@example.com',
+      name: 'Valid Name',
+      avatar: 'http://example.com/avatar.png',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty string email', () => {
+    const result = updateProfileSchema.safeParse({ email: '' });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid email with subdomain', () => {
+    const result = updateProfileSchema.safeParse({ email: 'user@mail.example.com' });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects email with spaces', () => {
+    const result = updateProfileSchema.safeParse({ email: 'user @example.com' });
+
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds regression coverage for route protection and validation contracts, and enhances the session lifecycle documentation.

### Changes

**New: `apps/api/src/modules/auth/tests/route-protection.test.ts`** — 16 regression tests covering:
- Public routes: register and login without authentication
- Authenticated routes: missing header, malformed header, empty Bearer, expired token, wrong secret, valid token
- Role-based routes: USER on ADMIN, ADMIN on ADMIN, expired token on ADMIN
- Ownership-based routes: self-update, cross-user rejection, missing params
- Error response consistency: consistent shape for 401 and 403

**Enhanced: `packages/shared/src/__tests__/auth.schema.test.ts`** — Added 12 regression tests:
- Register schema: strict mode (rejects extra fields), email normalization, whitespace trimming, invalid email formats, null/empty input, boundary conditions
- Login schema: strict mode, email normalization, null/empty input

**Enhanced: `packages/shared/src/__tests__/session.schema.test.ts`** — Added 11 regression tests:
- Refresh token: UUID format, max length boundary, undefined/boolean/array rejection
- Update profile: name boundary (100 chars), strict mode, empty email, subdomain email, email with spaces

**Enhanced: `apps/docs/session-lifecycle.md`** — Added scope section, concurrent session limits table, integration points, and edge cases covering token rotation, expired tokens, max sessions, and cross-user revocation.

### Backlog Keys

- S1-103 (route protection: add regression coverage)
- S1-018 (validation contracts: add regression coverage)
- S1-054 (web auth shell: harden edge cases and failure modes)
- S1-001 (session lifecycle: define scope and contracts)

Closes #785
Closes #700
Closes #736
Closes #683