### PR TITLE
feat(auth): implement core AuthGuard and Public decorator

### DIFF
--- a/apps/api/src/modules/auth/CHANGELOG.md
+++ b/apps/api/src/modules/auth/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog - Auth Module
+
+## [Unreleased]
+
+### Added
+- Implemented core `AuthGuard` for route execution context authorization (#689).
+- Added `@Public()` decorator to allow route-level authorization bypass (#689).
+- Unit test suite covering authorization headers and token verification (#689).

--- a/apps/api/src/modules/auth/decorators/public.decorator.ts
+++ b/apps/api/src/modules/auth/decorators/public.decorator.ts
@@ -1,0 +1,8 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+
+/**
+ * Decorator to bypass the global AuthGuard for public routes.
+ */
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/api/src/modules/guards/auth.guard.spec.ts
+++ b/apps/api/src/modules/guards/auth.guard.spec.ts
@@ -1,0 +1,72 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthGuard } from './auth.guard';
+import { AuthService } from '../auth.service';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let reflector: jest.Mocked<Reflector>;
+  let authService: jest.Mocked<AuthService>;
+
+  beforeEach(async () => {
+    const mockReflector = {
+      getAllAndOverride: jest.fn(),
+    };
+    const mockAuthService = {
+      verifyAccessToken: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthGuard,
+        { provide: Reflector, useValue: mockReflector },
+        { provide: AuthService, useValue: mockAuthService },
+      ],
+    }).compile();
+
+    guard = module.get(AuthGuard);
+    reflector = module.get(Reflector);
+    authService = module.get(AuthService);
+  });
+
+  it('should allow access if route is marked as @Public()', async () => {
+    reflector.getAllAndOverride.mockReturnValue(true);
+    const mockContext = createMockContext(undefined);
+
+    const canActivate = await guard.canActivate(mockContext);
+    expect(canActivate).toBe(true);
+  });
+
+  it('should throw UnauthorizedException if header is missing', async () => {
+    reflector.getAllAndOverride.mockReturnValue(false);
+    const mockContext = createMockContext(undefined);
+
+    await expect(guard.canActivate(mockContext)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('should validate token and attach user to request object', async () => {
+    reflector.getAllAndOverride.mockReturnValue(false);
+    authService.verifyAccessToken.mockResolvedValue({
+      address: 'GABCD1234567890',
+    });
+    const mockRequest = { headers: { authorization: 'Bearer valid.jwt.token' } };
+    const mockContext = createMockContext(mockRequest);
+
+    const canActivate = await guard.canActivate(mockContext);
+    expect(canActivate).toBe(true);
+    expect((mockRequest as any).user).toEqual({ address: 'GABCD1234567890' });
+  });
+});
+
+function createMockContext(request: any): ExecutionContext {
+  return {
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
+}

--- a/apps/api/src/modules/guards/auth.guard.ts
+++ b/apps/api/src/modules/guards/auth.guard.ts
@@ -1,0 +1,54 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { AuthService } from '../auth.service';
+
+/**
+ * Core Auth Guard for MixMatch-Onchain.
+ * Intercepts incoming requests, validates bearer tokens,
+ * and attaches authenticated user payload to the execution context.
+ */
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly authService: AuthService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // 1. Check if endpoint is decorated with @Public()
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+
+    // 2. Extract Authorization header
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Missing or malformed Authorization header');
+    }
+
+    const token = authHeader.split(' ')[1];
+
+    try {
+      // 3. Verify core token signature/claims
+      const user = await this.authService.verifyAccessToken(token);
+      
+      // 4. Attach user context to request
+      request.user = user;
+      return true;
+    } catch {
+      throw new UnauthorizedException('Invalid or expired authentication token');
+    }
+  }
+}


### PR DESCRIPTION
# 🎯 Summary
closes #689

Delivers the core end-to-end slice for the Sprint 1 `auth guard` workstream. It establishes an auth-first guard pattern using NestJS execution contexts and JWT/signature token verification while allowing unauthenticated bypass via `@Public()`.

---

## 🛠️ Key Architectural Changes
* Created `AuthGuard` checking for Authorization headers and validating access tokens against `AuthService`.
* Added `@Public()` decorator metadata reflector handling.
* Updated `CHANGELOG.md` to adhere to backend module changelog discipline.

---

## 🧪 Testing & Verification
```bash
npm run test src/modules/auth/guards/auth.guard.spec.ts
npm run typecheck