### PR TITLE
Add payment reconciliation job and review status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,12 @@ WALLET_ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=
 STELLAR_RPC_URL=
+
+# Background reconciliation job (apps/api/src/modules/payments/reconciliation.job.ts).
+# How often it re-checks stuck PENDING transactions against Horizon.
+RECONCILIATION_INTERVAL_MS=120000
+# How long a PENDING transaction is left alone before a reconciliation attempt is made.
+RECONCILIATION_STALE_MS=120000
+# How long reconciliation keeps retrying before giving up and marking a
+# transaction NEEDS_REVIEW instead of leaving it PENDING forever.
+RECONCILIATION_ESCALATION_MS=86400000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Lint (Turborepo)
-        run: pnpm lint
-
       - name: Build (Turborepo)
         run: pnpm build
 
-      # Uncomment below once unit tests are added to the apps
-      # - name: Run Tests
-      #   run: pnpm test
+      - name: Lint (Turborepo)
+        run: pnpm lint
+
+      - name: Check types (Turborepo)
+        run: pnpm check-types
+
+      - name: Run Tests
+        run: pnpm test

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -9,11 +9,20 @@ export interface EnvConfig {
   stellarNetwork: 'testnet' | 'public';
   stellarHorizonUrl?: string;
   stellarRpcUrl?: string;
+  /** How often the background job re-checks stuck PENDING transactions, in ms. */
+  reconciliationIntervalMs: number;
+  /** How long a PENDING transaction is left alone before a reconciliation attempt is made, in ms. */
+  reconciliationStaleMs: number;
+  /** How long reconciliation keeps retrying before giving up and flagging NEEDS_REVIEW, in ms. */
+  reconciliationEscalationMs: number;
 }
 
 const DEFAULT_PORT = 3000;
 const DEFAULT_JWT_EXPIRES_IN_SECONDS = 60 * 60; // 1 hour
 const MIN_JWT_SECRET_LENGTH = 32;
+const DEFAULT_RECONCILIATION_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
+const DEFAULT_RECONCILIATION_STALE_MS = 2 * 60 * 1000; // 2 minutes
+const DEFAULT_RECONCILIATION_ESCALATION_MS = 24 * 60 * 60 * 1000; // 24 hours
 /** AES-256-GCM key: 32 bytes, hex-encoded (64 hex characters). */
 const WALLET_ENCRYPTION_KEY_HEX_LENGTH = 64;
 
@@ -57,5 +66,13 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): EnvConfig {
     stellarNetwork,
     stellarHorizonUrl: env.STELLAR_HORIZON_URL?.trim(),
     stellarRpcUrl: env.STELLAR_RPC_URL?.trim(),
+    reconciliationIntervalMs:
+      Number(env.RECONCILIATION_INTERVAL_MS) ||
+      DEFAULT_RECONCILIATION_INTERVAL_MS,
+    reconciliationStaleMs:
+      Number(env.RECONCILIATION_STALE_MS) || DEFAULT_RECONCILIATION_STALE_MS,
+    reconciliationEscalationMs:
+      Number(env.RECONCILIATION_ESCALATION_MS) ||
+      DEFAULT_RECONCILIATION_ESCALATION_MS,
   };
 }

--- a/apps/api/src/db/migrations/0001_melodic_killer_shrike.sql
+++ b/apps/api/src/db/migrations/0001_melodic_killer_shrike.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."transaction_status" ADD VALUE 'NEEDS_REVIEW';

--- a/apps/api/src/db/migrations/meta/0001_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,475 @@
+{
+  "id": "8e366e86-b116-4b88-aeb3-77829e3c2b13",
+  "prevId": "b134aa61-53cd-4a6e-8b7f-91e879683df2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.stellar_accounts": {
+      "name": "stellar_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret_key": {
+          "name": "encrypted_secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "stellar_network",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'testnet'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stellar_accounts_user_id_users_id_fk": {
+          "name": "stellar_accounts_user_id_users_id_fk",
+          "tableFrom": "stellar_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stellar_accounts_user_id_unique": {
+          "name": "stellar_accounts_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "stellar_accounts_public_key_unique": {
+          "name": "stellar_accounts_public_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streaming_connections": {
+      "name": "streaming_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streaming_connections_user_id_users_id_fk": {
+          "name": "streaming_connections_user_id_users_id_fk",
+          "tableFrom": "streaming_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taste_profiles": {
+      "name": "taste_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acousticness": {
+          "name": "acousticness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "danceability": {
+          "name": "danceability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy": {
+          "name": "energy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valence": {
+          "name": "valence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "taste_profiles_user_id_users_id_fk": {
+          "name": "taste_profiles_user_id_users_id_fk",
+          "tableFrom": "taste_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stellar_account_id": {
+          "name": "stellar_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_public_key": {
+          "name": "destination_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "stellar_tx_hash": {
+          "name": "stellar_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_stellar_account_id_stellar_accounts_id_fk": {
+          "name": "transactions_stellar_account_id_stellar_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "stellar_accounts",
+          "columnsFrom": [
+            "stellar_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transactions_idempotency_key_unique": {
+          "name": "transactions_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "spotify",
+        "apple_music"
+      ]
+    },
+    "public.stellar_network": {
+      "name": "stellar_network",
+      "schema": "public",
+      "values": [
+        "testnet",
+        "public"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "SUCCESS",
+        "FAILED",
+        "NEEDS_REVIEW"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1787568388063,
       "tag": "0000_swift_shard",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1787576325428,
+      "tag": "0001_melodic_killer_shrike",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -19,6 +19,7 @@ export const transactionStatusEnum = pgEnum('transaction_status', [
   'PENDING',
   'SUCCESS',
   'FAILED',
+  'NEEDS_REVIEW',
 ]);
 
 // Identity Models

--- a/apps/api/src/modules/payments/payments.module.ts
+++ b/apps/api/src/modules/payments/payments.module.ts
@@ -3,13 +3,19 @@ import { AuthModule } from '../auth/auth.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { PaymentsController } from './payments.controller';
 import { PaymentsService } from './payments.service';
+import { ReconciliationJob } from './reconciliation.job';
 import { StellarAccountRepository } from './stellar-account.repository';
 import { TransactionRepository } from './transaction.repository';
 
 @Module({
   imports: [AuthModule, StellarModule],
   controllers: [PaymentsController],
-  providers: [PaymentsService, StellarAccountRepository, TransactionRepository],
+  providers: [
+    PaymentsService,
+    StellarAccountRepository,
+    TransactionRepository,
+    ReconciliationJob,
+  ],
   exports: [PaymentsService],
 })
 export class PaymentsModule {}

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -21,6 +21,14 @@ import {
 
 const ENCRYPTION_KEY = 'ab'.repeat(32);
 const REAL_TESTNET_SECRET = Keypair.random().secret();
+const RECONCILIATION_STALE_MS = 2 * 60 * 1000;
+const RECONCILIATION_ESCALATION_MS = 24 * 60 * 60 * 1000;
+
+const CONFIG_VALUES: Record<string, unknown> = {
+  walletEncryptionKey: ENCRYPTION_KEY,
+  reconciliationStaleMs: RECONCILIATION_STALE_MS,
+  reconciliationEscalationMs: RECONCILIATION_ESCALATION_MS,
+};
 
 function buildAccount(
   overrides: Partial<StellarAccountRecord> = {},
@@ -93,7 +101,7 @@ describe('PaymentsService', () => {
       stellarClient as unknown as DefaultStellarClient,
       paymentEngine as unknown as StellarPaymentEngine,
       {
-        getOrThrow: jest.fn().mockReturnValue(ENCRYPTION_KEY),
+        getOrThrow: jest.fn((key: string) => CONFIG_VALUES[key]),
       } as unknown as ConfigService,
     );
   });
@@ -220,6 +228,133 @@ describe('PaymentsService', () => {
       await expect(
         service.getTransactionStatus('user-1', 'tx-1'),
       ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+  });
+
+  describe('reconciliation', () => {
+    function mockHorizonPayments(records: unknown[]) {
+      const call = jest.fn().mockResolvedValue({ records });
+      const limit = jest.fn().mockReturnValue({ call });
+      const order = jest.fn().mockReturnValue({ limit });
+      const forAccount = jest.fn().mockReturnValue({ order });
+      stellarClient.horizon.payments = jest
+        .fn()
+        .mockReturnValue({ forAccount });
+    }
+
+    it('marks a stale transaction SUCCESS when a matching payment is found on-chain', async () => {
+      const account = buildAccount();
+      const transaction = buildTransaction({
+        status: 'PENDING',
+        createdAt: new Date(Date.now() - RECONCILIATION_STALE_MS - 1000),
+        amount: '10.0000000',
+        destinationPublicKey: 'GDEST',
+      });
+      transactionRepository.findById.mockResolvedValue(transaction);
+      stellarAccountRepository.findById.mockResolvedValue(account);
+      mockHorizonPayments([
+        {
+          type: 'payment',
+          asset_type: 'native',
+          to: 'GDEST',
+          amount: '10.0000000',
+          created_at: new Date(
+            transaction.createdAt.getTime() + 1000,
+          ).toISOString(),
+          transaction_hash: 'found-hash',
+        },
+      ]);
+      transactionRepository.updateStatus.mockImplementation(
+        (_id: string, update: object) =>
+          buildTransaction({ ...transaction, ...update }),
+      );
+
+      const result = await service.getTransactionStatus('user-1', 'tx-1');
+
+      expect(result.status).toBe('SUCCESS');
+      expect(result.stellarTxHash).toBe('found-hash');
+    });
+
+    it('leaves a stale transaction PENDING when unmatched but still within the escalation window', async () => {
+      const account = buildAccount();
+      const transaction = buildTransaction({
+        status: 'PENDING',
+        createdAt: new Date(Date.now() - RECONCILIATION_STALE_MS - 1000),
+      });
+      transactionRepository.findById.mockResolvedValue(transaction);
+      stellarAccountRepository.findById.mockResolvedValue(account);
+      mockHorizonPayments([]);
+
+      const result = await service.getTransactionStatus('user-1', 'tx-1');
+
+      expect(result.status).toBe('PENDING');
+      expect(transactionRepository.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('escalates to NEEDS_REVIEW once unmatched past the escalation window', async () => {
+      const account = buildAccount();
+      const transaction = buildTransaction({
+        status: 'PENDING',
+        createdAt: new Date(Date.now() - RECONCILIATION_ESCALATION_MS - 1000),
+      });
+      transactionRepository.findById.mockResolvedValue(transaction);
+      stellarAccountRepository.findById.mockResolvedValue(account);
+      mockHorizonPayments([]);
+      transactionRepository.updateStatus.mockImplementation(
+        (_id: string, update: object) =>
+          buildTransaction({ ...transaction, ...update }),
+      );
+
+      const result = await service.getTransactionStatus('user-1', 'tx-1');
+
+      expect(result.status).toBe('NEEDS_REVIEW');
+      expect(transactionRepository.updateStatus).toHaveBeenCalledWith(
+        'tx-1',
+        expect.objectContaining({
+          status: 'NEEDS_REVIEW',
+          failureCode: 'reconciliation_escalated',
+        }),
+      );
+    });
+
+    it('leaves a transaction PENDING when Horizon is unreachable, rather than escalating early', async () => {
+      const account = buildAccount();
+      const transaction = buildTransaction({
+        status: 'PENDING',
+        createdAt: new Date(Date.now() - RECONCILIATION_STALE_MS - 1000),
+      });
+      transactionRepository.findById.mockResolvedValue(transaction);
+      stellarAccountRepository.findById.mockResolvedValue(account);
+      stellarClient.horizon.payments = jest.fn().mockImplementation(() => {
+        throw new Error('ECONNREFUSED');
+      });
+
+      const result = await service.getTransactionStatus('user-1', 'tx-1');
+
+      expect(result.status).toBe('PENDING');
+    });
+
+    it('reconcilePendingTransactions processes every stale transaction returned by the repository', async () => {
+      const stale = [
+        buildTransaction({
+          id: 'tx-a',
+          createdAt: new Date(Date.now() - RECONCILIATION_STALE_MS - 1000),
+        }),
+        buildTransaction({
+          id: 'tx-b',
+          createdAt: new Date(Date.now() - RECONCILIATION_STALE_MS - 1000),
+        }),
+      ];
+      transactionRepository.findStalePending.mockResolvedValue(stale);
+      stellarAccountRepository.findById.mockResolvedValue(buildAccount());
+      mockHorizonPayments([]);
+
+      const result = await service.reconcilePendingTransactions();
+
+      expect(result).toHaveLength(2);
+      expect(transactionRepository.findStalePending).toHaveBeenCalledWith(
+        expect.any(Date),
+      );
     });
   });
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -27,9 +27,6 @@ import {
   type TransactionRecord,
 } from './transaction.repository';
 
-/** How long a PENDING transaction is left alone before reconciliation treats it as stuck. */
-const RECONCILIATION_STALE_MS = 2 * 60 * 1000;
-
 function normalizeAmount(amount: string): string {
   return Number(amount).toFixed(7);
 }
@@ -179,13 +176,13 @@ export class PaymentsService {
   }
 
   /**
-   * Batch reconciliation entry point for stuck PENDING transactions —
-   * intended to be invoked by a scheduled job (see the reconciliation-job
-   * issue in the Stellar track).
+   * Batch reconciliation entry point for stuck PENDING transactions.
+   * Invoked on a schedule by `ReconciliationJob` — see
+   * `apps/api/src/modules/payments/reconciliation.job.ts`.
    */
   async reconcilePendingTransactions(): Promise<TransactionRecord[]> {
     const stale = await this.transactionRepository.findStalePending(
-      new Date(Date.now() - RECONCILIATION_STALE_MS),
+      new Date(Date.now() - this.reconciliationStaleMs()),
     );
     const reconciled: TransactionRecord[] = [];
     for (const transaction of stale) {
@@ -196,7 +193,16 @@ export class PaymentsService {
 
   private isStale(transaction: TransactionRecord): boolean {
     return (
-      Date.now() - transaction.createdAt.getTime() > RECONCILIATION_STALE_MS
+      Date.now() - transaction.createdAt.getTime() >
+      this.reconciliationStaleMs()
+    );
+  }
+
+  /** True once a transaction has been stuck PENDING long enough that automatic retries should give up. */
+  private isPastEscalationWindow(transaction: TransactionRecord): boolean {
+    return (
+      Date.now() - transaction.createdAt.getTime() >
+      this.reconciliationEscalationMs()
     );
   }
 
@@ -249,12 +255,17 @@ export class PaymentsService {
       });
     }
 
-    if (this.isStale(transaction)) {
+    // No match yet — this is inherently a "not found so far" result, not
+    // proof the payment failed (Horizon may be lagging, or briefly
+    // unreachable). Only give up and flag it for manual review once we've
+    // been retrying across the full escalation window; before that, leave
+    // it PENDING so the next scheduled pass tries again.
+    if (this.isPastEscalationWindow(transaction)) {
       return this.transactionRepository.updateStatus(transaction.id, {
-        status: 'FAILED',
-        failureCode: 'reconciliation_timeout',
+        status: 'NEEDS_REVIEW',
+        failureCode: 'reconciliation_escalated',
         failureReason:
-          'No matching payment found on-chain within the reconciliation window',
+          'No matching payment found on-chain after repeated reconciliation attempts — needs manual verification against the ledger',
       });
     }
 
@@ -293,6 +304,14 @@ export class PaymentsService {
       // Horizon unreachable or query failed — leave PENDING, retry on the next pass.
     }
     return null;
+  }
+
+  private reconciliationStaleMs(): number {
+    return this.configService.getOrThrow<number>('reconciliationStaleMs');
+  }
+
+  private reconciliationEscalationMs(): number {
+    return this.configService.getOrThrow<number>('reconciliationEscalationMs');
   }
 
   private walletEncryptionKey(): string {

--- a/apps/api/src/modules/payments/reconciliation.job.spec.ts
+++ b/apps/api/src/modules/payments/reconciliation.job.spec.ts
@@ -1,0 +1,145 @@
+import { Logger } from '@nestjs/common';
+import type { ConfigService } from '@nestjs/config';
+import { ReconciliationJob } from './reconciliation.job';
+import type { PaymentsService } from './payments.service';
+import type { TransactionRecord } from './transaction.repository';
+
+function buildTransaction(
+  overrides: Partial<TransactionRecord> = {},
+): TransactionRecord {
+  return {
+    id: 'tx-1',
+    idempotencyKey: 'key-1',
+    stellarAccountId: 'account-1',
+    destinationPublicKey: 'GDEST',
+    amount: '10',
+    memo: null,
+    status: 'SUCCESS',
+    stellarTxHash: 'hash',
+    failureCode: null,
+    failureReason: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('ReconciliationJob', () => {
+  let job: ReconciliationJob;
+  let paymentsService: { reconcilePendingTransactions: jest.Mock };
+  let configService: { getOrThrow: jest.Mock };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    paymentsService = {
+      reconcilePendingTransactions: jest.fn().mockResolvedValue([]),
+    };
+    configService = { getOrThrow: jest.fn().mockReturnValue(120_000) };
+    job = new ReconciliationJob(
+      paymentsService as unknown as PaymentsService,
+      configService as unknown as ConfigService,
+    );
+  });
+
+  afterEach(() => {
+    job.onModuleDestroy();
+    jest.useRealTimers();
+  });
+
+  describe('runOnce', () => {
+    it('invokes PaymentsService.reconcilePendingTransactions', async () => {
+      await job.runOnce();
+      expect(
+        paymentsService.reconcilePendingTransactions,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips a run if the previous one is still in flight', async () => {
+      let resolveFirst!: (value: TransactionRecord[]) => void;
+      paymentsService.reconcilePendingTransactions.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      );
+
+      const first = job.runOnce();
+      const second = job.runOnce();
+
+      expect(
+        paymentsService.reconcilePendingTransactions,
+      ).toHaveBeenCalledTimes(1);
+      resolveFirst([]);
+      await first;
+      await second;
+    });
+
+    it('allows a new run once the previous one finishes', async () => {
+      await job.runOnce();
+      await job.runOnce();
+      expect(
+        paymentsService.reconcilePendingTransactions,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not throw when PaymentsService rejects, and clears the in-flight flag', async () => {
+      paymentsService.reconcilePendingTransactions.mockRejectedValueOnce(
+        new Error('horizon down'),
+      );
+
+      await expect(job.runOnce()).resolves.toBeUndefined();
+
+      paymentsService.reconcilePendingTransactions.mockResolvedValueOnce([]);
+      await job.runOnce();
+      expect(
+        paymentsService.reconcilePendingTransactions,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('logs a summary of how many transactions landed in each status', async () => {
+      paymentsService.reconcilePendingTransactions.mockResolvedValueOnce([
+        buildTransaction({ status: 'SUCCESS' }),
+        buildTransaction({ status: 'SUCCESS' }),
+        buildTransaction({ status: 'NEEDS_REVIEW' }),
+      ]);
+      const logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+
+      await job.runOnce();
+
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"SUCCESS":2'),
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"NEEDS_REVIEW":1'),
+      );
+    });
+  });
+
+  describe('onModuleInit / onModuleDestroy', () => {
+    it('schedules runOnce on the configured interval', () => {
+      const runOnceSpy = jest
+        .spyOn(job, 'runOnce')
+        .mockResolvedValue(undefined);
+
+      job.onModuleInit();
+      expect(runOnceSpy).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(120_000);
+      expect(runOnceSpy).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(120_000);
+      expect(runOnceSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops scheduling once destroyed', () => {
+      const runOnceSpy = jest
+        .spyOn(job, 'runOnce')
+        .mockResolvedValue(undefined);
+
+      job.onModuleInit();
+      job.onModuleDestroy();
+      jest.advanceTimersByTime(500_000);
+
+      expect(runOnceSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/modules/payments/reconciliation.job.ts
+++ b/apps/api/src/modules/payments/reconciliation.job.ts
@@ -1,0 +1,85 @@
+import {
+  Injectable,
+  Logger,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PaymentsService } from './payments.service';
+import type { TransactionRecord } from './transaction.repository';
+
+/**
+ * Periodically re-checks stuck PENDING transactions against Horizon so they
+ * resolve without a client ever having to poll `GET /:id/status` or call
+ * `POST /:id/reconcile` themselves. See `PaymentsService.reconcileTransaction`
+ * for the actual matching/escalation logic — this job is just the scheduler.
+ */
+@Injectable()
+export class ReconciliationJob implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(ReconciliationJob.name);
+  private timer?: ReturnType<typeof setInterval>;
+  private isRunning = false;
+
+  constructor(
+    private readonly paymentsService: PaymentsService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  onModuleInit(): void {
+    const intervalMs = this.configService.getOrThrow<number>(
+      'reconciliationIntervalMs',
+    );
+    this.timer = setInterval(() => {
+      void this.runOnce();
+    }, intervalMs);
+    // Don't let this timer keep the process alive on its own (relevant for
+    // graceful shutdown / short-lived test runs).
+    this.timer.unref?.();
+  }
+
+  onModuleDestroy(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+  }
+
+  /**
+   * Runs one reconciliation pass. Skips (rather than queues) if the previous
+   * pass is still in flight, so a slow Horizon response can't cause passes
+   * to pile up concurrently against the same rows.
+   */
+  async runOnce(): Promise<void> {
+    if (this.isRunning) {
+      this.logger.warn(
+        'Skipping reconciliation pass: the previous pass is still running',
+      );
+      return;
+    }
+
+    this.isRunning = true;
+    const start = Date.now();
+    try {
+      const results = await this.paymentsService.reconcilePendingTransactions();
+      this.logger.log(
+        `Reconciliation pass processed ${results.length} stale transaction(s) in ${Date.now() - start}ms — ${JSON.stringify(summarizeByStatus(results))}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        'Reconciliation pass failed',
+        error instanceof Error ? error.stack : String(error),
+      );
+    } finally {
+      this.isRunning = false;
+    }
+  }
+}
+
+function summarizeByStatus(
+  transactions: TransactionRecord[],
+): Record<string, number> {
+  const summary: Record<string, number> = {};
+  for (const transaction of transactions) {
+    summary[transaction.status] = (summary[transaction.status] ?? 0) + 1;
+  }
+  return summary;
+}

--- a/apps/mobile/src/components/TransactionHistoryList.tsx
+++ b/apps/mobile/src/components/TransactionHistoryList.tsx
@@ -9,6 +9,7 @@ const STATUS_COLOR: Record<TransactionRecord['status'], string> = {
   PENDING: '#b8860b',
   SUCCESS: '#0a0',
   FAILED: '#e00',
+  NEEDS_REVIEW: '#a05a00',
 };
 
 function TransactionRow({ transaction }: { transaction: TransactionRecord }) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "check-types": "turbo run check-types"
+    "check-types": "turbo run check-types",
+    "test": "turbo run test"
   },
   "devDependencies": {
     "prettier": "^3.7.4",

--- a/packages/shared/src/types/payments.ts
+++ b/packages/shared/src/types/payments.ts
@@ -1,4 +1,11 @@
-export type TransactionStatus = 'PENDING' | 'SUCCESS' | 'FAILED';
+/**
+ * `NEEDS_REVIEW` is distinct from `FAILED`: it means reconciliation could
+ * neither confirm nor rule out that the payment landed on-chain (e.g.
+ * Horizon was unreachable for the whole escalation window), so the outcome
+ * is genuinely unknown rather than a confirmed failure. It needs a human
+ * to check the ledger directly.
+ */
+export type TransactionStatus = 'PENDING' | 'SUCCESS' | 'FAILED' | 'NEEDS_REVIEW';
 
 export interface TransactionRecord {
   id: string;

--- a/turbo.json
+++ b/turbo.json
@@ -8,10 +8,13 @@
       "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**", "dist/**"]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^build", "^lint"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^build", "^check-types"]
+    },
+    "test": {
+      "dependsOn": ["^build"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
Introduces a scheduled payments reconciliation job that periodically re-checks stale PENDING transactions, avoids overlapping runs, and logs per-status outcomes. Reconciliation behavior is now configurable via env settings and escalates long-unresolved transactions to NEEDS_REVIEW instead of marking them as FAILED.

The change adds the new NEEDS_REVIEW transaction status across DB schema/migration, shared types, service logic, tests, and mobile UI status coloring. CI was also tightened to run build, lint, type checks, and tests in sequence, with a root test script added for Turborepo.

closes #855 