### PR TITLE
Add admin-gated multisig for high-value payments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,11 @@ RECONCILIATION_ESCALATION_MS=86400000
 # SEP-24 anchor for fiat deposit/withdraw (apps/api/src/modules/payments/anchor.service.ts).
 # Defaults to Stellar's own reference testnet anchor if unset.
 ANCHOR_HOME_DOMAIN=testanchor.stellar.org
+
+# High-value payment co-signing (apps/api/src/modules/payments/payments.service.ts,
+# @mixmatch/stellar's multisig.ts). Leave ADMIN_SIGNING_SECRET unset to disable
+# the gate entirely — payments proceed regardless of amount, as before this
+# feature existed. Set it to a funded Stellar secret key to turn it on.
+ADMIN_SIGNING_SECRET=
+# Native-XLM amount above which a payment requires admin co-signature.
+HIGH_VALUE_THRESHOLD_AMOUNT=1000

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -19,10 +19,21 @@ export interface EnvConfig {
   reconciliationEscalationMs: number;
   /** Home domain of the SEP-24 anchor used for fiat deposit/withdraw (see modules/payments/anchor.service.ts). */
   anchorHomeDomain: string;
+  /**
+   * Secret key of the platform's admin co-signer, used to approve
+   * high-value payments (see modules/payments/payments.service.ts and
+   * `@mixmatch/stellar`'s multisig.ts). Left unset, the high-value gate is
+   * disabled entirely — payments proceed regardless of amount, exactly as
+   * before this feature existed. Set it to turn the gate on.
+   */
+  adminSigningSecret?: string;
+  /** Native-XLM amount above which a payment requires admin co-signature; only enforced if `adminSigningSecret` is set. */
+  highValueThresholdAmount: string;
 }
 
 const DEFAULT_PORT = 3000;
 const DEFAULT_ANCHOR_HOME_DOMAIN = 'testanchor.stellar.org';
+const DEFAULT_HIGH_VALUE_THRESHOLD_AMOUNT = '1000';
 const DEFAULT_JWT_EXPIRES_IN_SECONDS = 60 * 60; // 1 hour
 const MIN_JWT_SECRET_LENGTH = 32;
 const DEFAULT_RECONCILIATION_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
@@ -82,5 +93,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): EnvConfig {
       DEFAULT_RECONCILIATION_ESCALATION_MS,
     anchorHomeDomain:
       env.ANCHOR_HOME_DOMAIN?.trim() || DEFAULT_ANCHOR_HOME_DOMAIN,
+    adminSigningSecret: env.ADMIN_SIGNING_SECRET?.trim() || undefined,
+    highValueThresholdAmount:
+      env.HIGH_VALUE_THRESHOLD_AMOUNT?.trim() ||
+      DEFAULT_HIGH_VALUE_THRESHOLD_AMOUNT,
   };
 }

--- a/apps/api/src/db/migrations/0006_grey_masque.sql
+++ b/apps/api/src/db/migrations/0006_grey_masque.sql
@@ -1,0 +1,5 @@
+CREATE TYPE "public"."user_role" AS ENUM('USER', 'ADMIN');--> statement-breakpoint
+ALTER TYPE "public"."transaction_status" ADD VALUE 'PENDING_SIGNATURE' BEFORE 'SUCCESS';--> statement-breakpoint
+ALTER TABLE "stellar_accounts" ADD COLUMN "multisig_configured" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "transactions" ADD COLUMN "pending_envelope_xdr" text;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "role" "user_role" DEFAULT 'USER' NOT NULL;

--- a/apps/api/src/db/migrations/meta/0006_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,851 @@
+{
+  "id": "5b5259a8-f6de-49b5-a2dd-bfcbb6cc2dd3",
+  "prevId": "38777278-a04c-462e-976d-43f9e8d8a40d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.anchor_transactions": {
+      "name": "anchor_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stellar_account_id": {
+          "name": "stellar_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "anchor_transaction_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_code": {
+          "name": "asset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_domain": {
+          "name": "home_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sep24_transaction_id": {
+          "name": "sep24_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "anchor_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interactive_url": {
+          "name": "interactive_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "more_info_url": {
+          "name": "more_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_in": {
+          "name": "amount_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_out": {
+          "name": "amount_out",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stellar_transaction_id": {
+          "name": "stellar_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_transaction_id": {
+          "name": "external_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anchor_transactions_stellar_account_id_stellar_accounts_id_fk": {
+          "name": "anchor_transactions_stellar_account_id_stellar_accounts_id_fk",
+          "tableFrom": "anchor_transactions",
+          "tableTo": "stellar_accounts",
+          "columnsFrom": [
+            "stellar_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "anchor_transactions_sep24_transaction_id_unique": {
+          "name": "anchor_transactions_sep24_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sep24_transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escrows": {
+      "name": "escrows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_stellar_account_id": {
+          "name": "payer_stellar_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee_public_key": {
+          "name": "payee_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_contract_id": {
+          "name": "token_contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "on_chain_escrow_id": {
+          "name": "on_chain_escrow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ledger": {
+          "name": "timeout_ledger",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "escrow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "deposit_tx_hash": {
+          "name": "deposit_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalize_tx_hash": {
+          "name": "finalize_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "escrows_payer_stellar_account_id_stellar_accounts_id_fk": {
+          "name": "escrows_payer_stellar_account_id_stellar_accounts_id_fk",
+          "tableFrom": "escrows",
+          "tableTo": "stellar_accounts",
+          "columnsFrom": [
+            "payer_stellar_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "escrows_idempotency_key_unique": {
+          "name": "escrows_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stellar_accounts": {
+      "name": "stellar_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret_key": {
+          "name": "encrypted_secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "stellar_network",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'testnet'"
+        },
+        "multisig_configured": {
+          "name": "multisig_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stellar_accounts_user_id_users_id_fk": {
+          "name": "stellar_accounts_user_id_users_id_fk",
+          "tableFrom": "stellar_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stellar_accounts_user_id_unique": {
+          "name": "stellar_accounts_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "stellar_accounts_public_key_unique": {
+          "name": "stellar_accounts_public_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streaming_connections": {
+      "name": "streaming_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streaming_connections_user_id_users_id_fk": {
+          "name": "streaming_connections_user_id_users_id_fk",
+          "tableFrom": "streaming_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taste_profiles": {
+      "name": "taste_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acousticness": {
+          "name": "acousticness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "danceability": {
+          "name": "danceability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy": {
+          "name": "energy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valence": {
+          "name": "valence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "taste_profiles_user_id_users_id_fk": {
+          "name": "taste_profiles_user_id_users_id_fk",
+          "tableFrom": "taste_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stellar_account_id": {
+          "name": "stellar_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_public_key": {
+          "name": "destination_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_code": {
+          "name": "asset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_issuer": {
+          "name": "asset_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_asset_code": {
+          "name": "receive_asset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_asset_issuer": {
+          "name": "receive_asset_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dest_amount": {
+          "name": "dest_amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_envelope_xdr": {
+          "name": "pending_envelope_xdr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "stellar_tx_hash": {
+          "name": "stellar_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_stellar_account_id_stellar_accounts_id_fk": {
+          "name": "transactions_stellar_account_id_stellar_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "stellar_accounts",
+          "columnsFrom": [
+            "stellar_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transactions_idempotency_key_unique": {
+          "name": "transactions_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.anchor_transaction_kind": {
+      "name": "anchor_transaction_kind",
+      "schema": "public",
+      "values": [
+        "deposit",
+        "withdrawal"
+      ]
+    },
+    "public.anchor_transaction_status": {
+      "name": "anchor_transaction_status",
+      "schema": "public",
+      "values": [
+        "incomplete",
+        "pending_user_transfer_start",
+        "pending_user_transfer_complete",
+        "pending_external",
+        "pending_anchor",
+        "pending_stellar",
+        "pending_trust",
+        "pending_user",
+        "on_hold",
+        "completed",
+        "refunded",
+        "expired",
+        "error"
+      ]
+    },
+    "public.escrow_status": {
+      "name": "escrow_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "LOCKED",
+        "RELEASED",
+        "REFUNDED",
+        "FAILED"
+      ]
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "spotify",
+        "apple_music"
+      ]
+    },
+    "public.stellar_network": {
+      "name": "stellar_network",
+      "schema": "public",
+      "values": [
+        "testnet",
+        "public"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "PENDING_SIGNATURE",
+        "SUCCESS",
+        "FAILED",
+        "NEEDS_REVIEW"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "USER",
+        "ADMIN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1787595700394,
       "tag": "0005_furry_songbird",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1787653676570,
+      "tag": "0006_grey_masque",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -8,16 +8,22 @@ import {
   real,
   vector,
   integer,
+  boolean,
 } from 'drizzle-orm/pg-core';
 
 // Enums
 export const providerEnum = pgEnum('provider', ['spotify', 'apple_music']);
+export const userRoleEnum = pgEnum('user_role', ['USER', 'ADMIN']);
 export const stellarNetworkEnum = pgEnum('stellar_network', [
   'testnet',
   'public',
 ]);
 export const transactionStatusEnum = pgEnum('transaction_status', [
   'PENDING',
+  // Above the high-value threshold: the caller's own signature is on file
+  // but an admin co-signature is still required before submission. See
+  // modules/payments/multisig — apps/api/src/modules/payments/payments.service.ts.
+  'PENDING_SIGNATURE',
   'SUCCESS',
   'FAILED',
   'NEEDS_REVIEW',
@@ -57,6 +63,7 @@ export const users = pgTable('users', {
   id: uuid('id').defaultRandom().primaryKey(),
   email: text('email').unique().notNull(),
   passwordHash: text('password_hash'),
+  role: userRoleEnum('role').default('USER').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });
@@ -104,6 +111,11 @@ export const stellarAccounts = pgTable('stellar_accounts', {
   // modules/payments/wallet-encryption.ts. Never stored in plaintext.
   encryptedSecretKey: text('encrypted_secret_key').notNull(),
   network: stellarNetworkEnum('network').default('testnet').notNull(),
+  // True once the account has had the platform's admin key added as a
+  // co-signer and thresholds configured (see multisig.ts's
+  // configureMultisig) — done lazily on the account's first high-value
+  // payment, not at account creation.
+  multisigConfigured: boolean('multisig_configured').default(false).notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });
@@ -134,6 +146,11 @@ export const transactions = pgTable('transactions', {
   receiveAssetCode: text('receive_asset_code'),
   receiveAssetIssuer: text('receive_asset_issuer'),
   destAmount: text('dest_amount'),
+  // Set only while status is PENDING_SIGNATURE: the payment transaction,
+  // signed by the account's own key, awaiting an admin co-signature
+  // before it can be submitted. Cleared once resolved (approved or
+  // rejected) either way — never kept around once acted on.
+  pendingEnvelopeXdr: text('pending_envelope_xdr'),
   status: transactionStatusEnum('status').default('PENDING').notNull(),
   stellarTxHash: text('stellar_tx_hash'),
   failureCode: text('failure_code'),

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { UsersRepository } from '../users/users.repository';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { RolesGuard } from './roles.guard';
 
 @Module({
   imports: [
@@ -20,7 +21,7 @@ import { JwtAuthGuard } from './jwt-auth.guard';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, UsersRepository, JwtAuthGuard],
-  exports: [JwtAuthGuard, JwtModule],
+  providers: [AuthService, UsersRepository, JwtAuthGuard, RolesGuard],
+  exports: [JwtAuthGuard, RolesGuard, JwtModule],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/auth.service.spec.ts
@@ -11,6 +11,7 @@ function buildUser(overrides: Partial<User> = {}): User {
     id: 'user-1',
     email: 'user@example.com',
     passwordHash: null,
+    role: 'USER',
     createdAt: new Date('2025-01-01T00:00:00.000Z'),
     updatedAt: new Date('2025-01-01T00:00:00.000Z'),
     ...overrides,

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -19,6 +19,7 @@ function toAuthUser(user: User): AuthUser {
   return {
     id: user.id,
     email: user.email,
+    role: user.role,
     createdAt: user.createdAt.toISOString(),
     updatedAt: user.updatedAt.toISOString(),
   };
@@ -69,7 +70,7 @@ export class AuthService {
   }
 
   private buildTokenResponse(user: User): AuthTokenResponse {
-    const accessToken = this.jwtService.sign({ sub: user.id });
+    const accessToken = this.jwtService.sign({ sub: user.id, role: user.role });
     return { user: toAuthUser(user), accessToken };
   }
 }

--- a/apps/api/src/modules/auth/jwt-auth.guard.ts
+++ b/apps/api/src/modules/auth/jwt-auth.guard.ts
@@ -5,14 +5,18 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import type { UserRole } from '@mixmatch/shared';
 import type { Request } from 'express';
 
 export interface JwtPayload {
   sub: string;
+  role?: UserRole;
 }
 
 export interface AuthenticatedRequest extends Request {
   userId: string;
+  /** Absent on tokens issued before role claims existed — treated as `'USER'` by `RolesGuard`. */
+  userRole?: UserRole;
 }
 
 @Injectable()
@@ -37,6 +41,7 @@ export class JwtAuthGuard implements CanActivate {
         throw new UnauthorizedException('Token is missing a subject claim');
       }
       request.userId = payload.sub;
+      request.userRole = payload.role;
       return true;
     } catch {
       throw new UnauthorizedException('Invalid or expired token');

--- a/apps/api/src/modules/auth/roles.decorator.ts
+++ b/apps/api/src/modules/auth/roles.decorator.ts
@@ -1,0 +1,7 @@
+import { SetMetadata } from '@nestjs/common';
+import type { UserRole } from '@mixmatch/shared';
+
+export const ROLES_KEY = 'roles';
+
+/** Restricts a route to callers whose JWT carries one of the given roles. Must be paired with `JwtAuthGuard` (runs first) and `RolesGuard`. */
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/api/src/modules/auth/roles.guard.spec.ts
+++ b/apps/api/src/modules/auth/roles.guard.spec.ts
@@ -1,0 +1,58 @@
+import { ForbiddenException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import type { AuthenticatedRequest } from './jwt-auth.guard';
+
+function buildContext(userRole: string | undefined): ExecutionContext {
+  const request: Partial<AuthenticatedRequest> = {
+    userRole: userRole as never,
+  };
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+    getHandler: () => ({}) as never,
+    getClass: () => ({}) as never,
+  } as unknown as ExecutionContext;
+}
+
+describe('RolesGuard', () => {
+  it('allows the request through when no @Roles metadata is present', () => {
+    const reflector = {
+      getAllAndOverride: jest.fn().mockReturnValue(undefined),
+    } as unknown as Reflector;
+    const guard = new RolesGuard(reflector);
+
+    expect(guard.canActivate(buildContext('USER'))).toBe(true);
+  });
+
+  it('allows an ADMIN through a route requiring ADMIN', () => {
+    const reflector = {
+      getAllAndOverride: jest.fn().mockReturnValue(['ADMIN']),
+    } as unknown as Reflector;
+    const guard = new RolesGuard(reflector);
+
+    expect(guard.canActivate(buildContext('ADMIN'))).toBe(true);
+  });
+
+  it('rejects a USER on a route requiring ADMIN', () => {
+    const reflector = {
+      getAllAndOverride: jest.fn().mockReturnValue(['ADMIN']),
+    } as unknown as Reflector;
+    const guard = new RolesGuard(reflector);
+
+    expect(() => guard.canActivate(buildContext('USER'))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('treats a token with no role claim as USER', () => {
+    const reflector = {
+      getAllAndOverride: jest.fn().mockReturnValue(['ADMIN']),
+    } as unknown as Reflector;
+    const guard = new RolesGuard(reflector);
+
+    expect(() => guard.canActivate(buildContext(undefined))).toThrow(
+      ForbiddenException,
+    );
+  });
+});

--- a/apps/api/src/modules/auth/roles.guard.ts
+++ b/apps/api/src/modules/auth/roles.guard.ts
@@ -1,0 +1,34 @@
+import {
+  type CanActivate,
+  type ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { UserRole } from '@mixmatch/shared';
+import type { AuthenticatedRequest } from './jwt-auth.guard';
+import { ROLES_KEY } from './roles.decorator';
+
+/** Enforces `@Roles(...)` — must run after `JwtAuthGuard` so `request.userRole` is set. */
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<
+      UserRole[] | undefined
+    >(ROLES_KEY, [context.getHandler(), context.getClass()]);
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const role = request.userRole ?? 'USER';
+    if (!requiredRoles.includes(role)) {
+      throw new ForbiddenException(
+        'You do not have permission to perform this action',
+      );
+    }
+    return true;
+  }
+}

--- a/apps/api/src/modules/payments/admin.controller.ts
+++ b/apps/api/src/modules/payments/admin.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { PaymentsService } from './payments.service';
+
+/** Admin-only endpoints for approving/rejecting high-value payments awaiting a co-signature. */
+@Controller('admin/transactions')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+export class AdminController {
+  constructor(private readonly paymentsService: PaymentsService) {}
+
+  @Get('pending-signature')
+  async listPendingSignatures() {
+    const transactions = await this.paymentsService.listPendingSignatures();
+    return { transactions };
+  }
+
+  @Post(':id/approve')
+  async approve(@Param('id') id: string) {
+    const transaction = await this.paymentsService.approvePendingSignature(id);
+    return { transaction };
+  }
+
+  @Post(':id/reject')
+  async reject(@Param('id') id: string) {
+    const transaction = await this.paymentsService.rejectPendingSignature(id);
+    return { transaction };
+  }
+}

--- a/apps/api/src/modules/payments/anchor.service.spec.ts
+++ b/apps/api/src/modules/payments/anchor.service.spec.ts
@@ -81,6 +81,7 @@ function buildAccount(
     publicKey: 'GABCDEF',
     encryptedSecretKey: encryptSecretKey(REAL_TESTNET_SECRET, ENCRYPTION_KEY),
     network: 'testnet',
+    multisigConfigured: false,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,

--- a/apps/api/src/modules/payments/escrow.service.spec.ts
+++ b/apps/api/src/modules/payments/escrow.service.spec.ts
@@ -116,6 +116,7 @@ function buildAccount(
     publicKey: 'GABCDEF',
     encryptedSecretKey: encryptSecretKey(REAL_TESTNET_SECRET, ENCRYPTION_KEY),
     network: 'testnet',
+    multisigConfigured: false,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,

--- a/apps/api/src/modules/payments/payments.module.ts
+++ b/apps/api/src/modules/payments/payments.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { AdminController } from './admin.controller';
 import { AnchorController } from './anchor.controller';
 import { AnchorService } from './anchor.service';
 import { AnchorTransactionRepository } from './anchor-transaction.repository';
@@ -15,7 +16,12 @@ import { TransactionRepository } from './transaction.repository';
 
 @Module({
   imports: [AuthModule, StellarModule],
-  controllers: [PaymentsController, EscrowController, AnchorController],
+  controllers: [
+    PaymentsController,
+    EscrowController,
+    AnchorController,
+    AdminController,
+  ],
   providers: [
     PaymentsService,
     StellarAccountRepository,

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -49,6 +49,29 @@ const submitPathPaymentMock = jest.fn<
   Parameters<SubmitPathPaymentFn>
 >();
 
+type ConfigureMultisigFn = (input: {
+  adminPublicKey: string;
+}) => Promise<{ hash: string; ledger: number }>;
+type BuildHighValuePaymentEnvelopeFn = (input: {
+  amount: string;
+}) => Promise<{ envelopeXdr: string }>;
+type CoSignAndSubmitEnvelopeFn = (input: {
+  envelopeXdr: string;
+}) => Promise<{ hash: string; ledger: number }>;
+
+const configureMultisigMock = jest.fn<
+  Promise<{ hash: string; ledger: number }>,
+  Parameters<ConfigureMultisigFn>
+>();
+const buildHighValuePaymentEnvelopeMock = jest.fn<
+  Promise<{ envelopeXdr: string }>,
+  Parameters<BuildHighValuePaymentEnvelopeFn>
+>();
+const coSignAndSubmitEnvelopeMock = jest.fn<
+  Promise<{ hash: string; ledger: number }>,
+  Parameters<CoSignAndSubmitEnvelopeFn>
+>();
+
 jest.mock('@mixmatch/stellar', () => {
   const actual: object = jest.requireActual('@mixmatch/stellar');
   const establishTrustline: EstablishTrustlineFn = (input) =>
@@ -59,12 +82,22 @@ jest.mock('@mixmatch/stellar', () => {
     findStrictReceivePathMock(input);
   const submitPathPayment: SubmitPathPaymentFn = (input) =>
     submitPathPaymentMock(input);
+  const configureMultisig: ConfigureMultisigFn = (input) =>
+    configureMultisigMock(input);
+  const buildHighValuePaymentEnvelope: BuildHighValuePaymentEnvelopeFn = (
+    input,
+  ) => buildHighValuePaymentEnvelopeMock(input);
+  const coSignAndSubmitEnvelope: CoSignAndSubmitEnvelopeFn = (input) =>
+    coSignAndSubmitEnvelopeMock(input);
   return {
     ...actual,
     establishTrustline,
     findStrictSendPath,
     findStrictReceivePath,
     submitPathPayment,
+    configureMultisig,
+    buildHighValuePaymentEnvelope,
+    coSignAndSubmitEnvelope,
   };
 });
 import { encryptSecretKey } from './wallet-encryption';
@@ -100,6 +133,7 @@ function buildAccount(
     publicKey: 'GABCDEF',
     encryptedSecretKey: encryptSecretKey(REAL_TESTNET_SECRET, ENCRYPTION_KEY),
     network: 'testnet',
+    multisigConfigured: false,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -121,6 +155,7 @@ function buildTransaction(
     receiveAssetCode: null,
     receiveAssetIssuer: null,
     destAmount: null,
+    pendingEnvelopeXdr: null,
     status: 'PENDING',
     stellarTxHash: null,
     failureCode: null,
@@ -146,10 +181,14 @@ describe('PaymentsService', () => {
     findStrictSendPathMock.mockReset();
     findStrictReceivePathMock.mockReset();
     submitPathPaymentMock.mockReset();
+    configureMultisigMock.mockReset();
+    buildHighValuePaymentEnvelopeMock.mockReset();
+    coSignAndSubmitEnvelopeMock.mockReset();
     stellarAccountRepository = {
       findByUserId: jest.fn(),
       findById: jest.fn(),
       create: jest.fn(),
+      markMultisigConfigured: jest.fn(),
     };
     transactionRepository = {
       create: jest.fn(),
@@ -172,6 +211,7 @@ describe('PaymentsService', () => {
       paymentEngine as unknown as StellarPaymentEngine,
       {
         getOrThrow: jest.fn((key: string) => CONFIG_VALUES[key]),
+        get: jest.fn((key: string) => CONFIG_VALUES[key]),
       } as unknown as ConfigService,
     );
   });
@@ -438,6 +478,263 @@ describe('PaymentsService', () => {
           failureCode: 'slippage_exceeded',
         }),
       );
+    });
+  });
+
+  describe('sendPayment (high-value / multisig)', () => {
+    const ADMIN_SECRET = Keypair.random().secret();
+    const HIGH_VALUE_THRESHOLD_AMOUNT = '1000';
+
+    beforeEach(() => {
+      CONFIG_VALUES.adminSigningSecret = ADMIN_SECRET;
+      CONFIG_VALUES.highValueThresholdAmount = HIGH_VALUE_THRESHOLD_AMOUNT;
+    });
+
+    afterEach(() => {
+      delete CONFIG_VALUES.adminSigningSecret;
+      delete CONFIG_VALUES.highValueThresholdAmount;
+    });
+
+    it('leaves below-threshold payments unaffected — no multisig calls at all', async () => {
+      stellarAccountRepository.findByUserId.mockResolvedValue(buildAccount());
+      transactionRepository.create.mockResolvedValue(
+        buildTransaction({ amount: '10' }),
+      );
+      paymentEngine.submitPayment.mockResolvedValue({
+        hash: 'tx-hash',
+        ledger: 1,
+      });
+      transactionRepository.updateStatus.mockImplementation(
+        (_id: string, update: object) => buildTransaction({ ...update }),
+      );
+
+      const result = await service.sendPayment('user-1', {
+        destinationPublicKey: 'GDEST',
+        amount: '10',
+      });
+
+      expect(result.status).toBe('SUCCESS');
+      expect(configureMultisigMock).not.toHaveBeenCalled();
+      expect(buildHighValuePaymentEnvelopeMock).not.toHaveBeenCalled();
+      expect(paymentEngine.submitPayment).toHaveBeenCalled();
+    });
+
+    it('leaves a payment at exactly the threshold unaffected (strictly greater-than gates it)', async () => {
+      stellarAccountRepository.findByUserId.mockResolvedValue(buildAccount());
+      transactionRepository.create.mockResolvedValue(
+        buildTransaction({ amount: HIGH_VALUE_THRESHOLD_AMOUNT }),
+      );
+      paymentEngine.submitPayment.mockResolvedValue({
+        hash: 'tx-hash',
+        ledger: 1,
+      });
+      transactionRepository.updateStatus.mockImplementation(
+        (_id: string, update: object) => buildTransaction({ ...update }),
+      );
+
+      await service.sendPayment('user-1', {
+        destinationPublicKey: 'GDEST',
+        amount: HIGH_VALUE_THRESHOLD_AMOUNT,
+      });
+
+      expect(buildHighValuePaymentEnvelopeMock).not.toHaveBeenCalled();
+    });
+
+    it("configures multisig on the account's first high-value payment, then builds and persists a PENDING_SIGNATURE envelope without submitting", async () => {
+      const account = buildAccount({ multisigConfigured: false });
+      stellarAccountRepository.findByUserId.mockResolvedValue(account);
+      transactionRepository.findByIdempotencyKey.mockResolvedValue(null);
+      configureMultisigMock.mockResolvedValue({
+        hash: 'config-hash',
+        ledger: 1,
+      });
+      stellarAccountRepository.markMultisigConfigured.mockResolvedValue(
+        buildAccount({ multisigConfigured: true }),
+      );
+      buildHighValuePaymentEnvelopeMock.mockResolvedValue({
+        envelopeXdr: 'envelope-xdr',
+      });
+      transactionRepository.create.mockResolvedValue(
+        buildTransaction({ amount: '5000', status: 'PENDING_SIGNATURE' }),
+      );
+
+      const result = await service.sendPayment('user-1', {
+        destinationPublicKey: 'GDEST',
+        amount: '5000',
+      });
+
+      expect(result.status).toBe('PENDING_SIGNATURE');
+      expect(configureMultisigMock).toHaveBeenCalledTimes(1);
+      expect(
+        stellarAccountRepository.markMultisigConfigured,
+      ).toHaveBeenCalledWith('account-1');
+      expect(buildHighValuePaymentEnvelopeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: '5000',
+          destinationPublicKey: 'GDEST',
+        }),
+      );
+      expect(transactionRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ pendingEnvelopeXdr: 'envelope-xdr' }),
+      );
+      expect(paymentEngine.submitPayment).not.toHaveBeenCalled();
+    });
+
+    it('skips re-configuring multisig when the account is already configured', async () => {
+      const account = buildAccount({ multisigConfigured: true });
+      stellarAccountRepository.findByUserId.mockResolvedValue(account);
+      transactionRepository.findByIdempotencyKey.mockResolvedValue(null);
+      buildHighValuePaymentEnvelopeMock.mockResolvedValue({
+        envelopeXdr: 'envelope-xdr',
+      });
+      transactionRepository.create.mockResolvedValue(
+        buildTransaction({ amount: '5000', status: 'PENDING_SIGNATURE' }),
+      );
+
+      await service.sendPayment('user-1', {
+        destinationPublicKey: 'GDEST',
+        amount: '5000',
+      });
+
+      expect(configureMultisigMock).not.toHaveBeenCalled();
+    });
+
+    it('returns the existing transaction on a duplicate idempotency key instead of building a new envelope', async () => {
+      stellarAccountRepository.findByUserId.mockResolvedValue(
+        buildAccount({ multisigConfigured: true }),
+      );
+      const existing = buildTransaction({
+        status: 'PENDING_SIGNATURE',
+        amount: '5000',
+      });
+      transactionRepository.findByIdempotencyKey.mockResolvedValue(existing);
+
+      const result = await service.sendPayment('user-1', {
+        destinationPublicKey: 'GDEST',
+        amount: '5000',
+        idempotencyKey: 'key-1',
+      });
+
+      expect(result).toBe(existing);
+      expect(buildHighValuePaymentEnvelopeMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('approvePendingSignature', () => {
+    it('co-signs and submits, marking the transaction SUCCESS and clearing the envelope', async () => {
+      const pending = buildTransaction({
+        status: 'PENDING_SIGNATURE',
+        pendingEnvelopeXdr: 'envelope-xdr',
+      });
+      transactionRepository.findById.mockResolvedValue(pending);
+      CONFIG_VALUES.adminSigningSecret = Keypair.random().secret();
+      coSignAndSubmitEnvelopeMock.mockResolvedValue({
+        hash: 'final-hash',
+        ledger: 1,
+      });
+      transactionRepository.updateStatus.mockResolvedValue(
+        buildTransaction({ status: 'SUCCESS', stellarTxHash: 'final-hash' }),
+      );
+
+      const result = await service.approvePendingSignature('tx-1');
+
+      expect(result.status).toBe('SUCCESS');
+      expect(coSignAndSubmitEnvelopeMock).toHaveBeenCalledWith(
+        expect.objectContaining({ envelopeXdr: 'envelope-xdr' }),
+      );
+      expect(transactionRepository.updateStatus).toHaveBeenCalledWith(
+        'tx-1',
+        expect.objectContaining({
+          status: 'SUCCESS',
+          stellarTxHash: 'final-hash',
+          clearPendingEnvelope: true,
+        }),
+      );
+      delete CONFIG_VALUES.adminSigningSecret;
+    });
+
+    it('marks the transaction FAILED when co-signed submission fails (e.g. rejected second signature)', async () => {
+      const pending = buildTransaction({
+        status: 'PENDING_SIGNATURE',
+        pendingEnvelopeXdr: 'envelope-xdr',
+      });
+      transactionRepository.findById.mockResolvedValue(pending);
+      CONFIG_VALUES.adminSigningSecret = Keypair.random().secret();
+      coSignAndSubmitEnvelopeMock.mockRejectedValue(
+        new StellarPaymentError('malformed_transaction', 'bad auth'),
+      );
+      transactionRepository.updateStatus.mockResolvedValue(
+        buildTransaction({ status: 'FAILED' }),
+      );
+
+      await expect(
+        service.approvePendingSignature('tx-1'),
+      ).rejects.toBeInstanceOf(PaymentFailedError);
+      expect(transactionRepository.updateStatus).toHaveBeenCalledWith(
+        'tx-1',
+        expect.objectContaining({
+          status: 'FAILED',
+          clearPendingEnvelope: true,
+        }),
+      );
+      delete CONFIG_VALUES.adminSigningSecret;
+    });
+
+    it('throws when the transaction is not awaiting a signature', async () => {
+      transactionRepository.findById.mockResolvedValue(
+        buildTransaction({ status: 'SUCCESS' }),
+      );
+
+      await expect(
+        service.approvePendingSignature('tx-1'),
+      ).rejects.toBeInstanceOf(PaymentFailedError);
+      expect(coSignAndSubmitEnvelopeMock).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException for a transaction that does not exist', async () => {
+      transactionRepository.findById.mockResolvedValue(null);
+
+      await expect(
+        service.approvePendingSignature('missing'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('rejectPendingSignature', () => {
+    it('marks the transaction FAILED without ever attempting submission', async () => {
+      const pending = buildTransaction({
+        status: 'PENDING_SIGNATURE',
+        pendingEnvelopeXdr: 'envelope-xdr',
+      });
+      transactionRepository.findById.mockResolvedValue(pending);
+      transactionRepository.updateStatus.mockResolvedValue(
+        buildTransaction({ status: 'FAILED', failureCode: 'admin_rejected' }),
+      );
+
+      const result = await service.rejectPendingSignature('tx-1');
+
+      expect(result.status).toBe('FAILED');
+      expect(coSignAndSubmitEnvelopeMock).not.toHaveBeenCalled();
+      expect(transactionRepository.updateStatus).toHaveBeenCalledWith(
+        'tx-1',
+        expect.objectContaining({
+          status: 'FAILED',
+          failureCode: 'admin_rejected',
+          clearPendingEnvelope: true,
+        }),
+      );
+    });
+  });
+
+  describe('listPendingSignatures', () => {
+    it('returns every transaction awaiting a co-signature', async () => {
+      transactionRepository.findPendingSignature = jest
+        .fn()
+        .mockResolvedValue([buildTransaction({ status: 'PENDING_SIGNATURE' })]);
+
+      const result = await service.listPendingSignatures();
+
+      expect(result).toHaveLength(1);
     });
   });
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -6,7 +6,10 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
+  buildHighValuePaymentEnvelope,
   classifyStellarPaymentError,
+  configureMultisig,
+  coSignAndSubmitEnvelope,
   DefaultStellarClient,
   establishTrustline,
   findStrictReceivePath,
@@ -120,6 +123,10 @@ export class PaymentsService {
       quote = await this.resolvePathQuote(input);
     }
 
+    if (this.isHighValuePayment(input, quote)) {
+      return this.sendHighValuePayment(account, input, idempotencyKey);
+    }
+
     let transaction: TransactionRecord;
     try {
       transaction = await this.transactionRepository.create({
@@ -187,6 +194,197 @@ export class PaymentsService {
       });
       throw new PaymentFailedError(classified.kind, classified.message);
     }
+  }
+
+  /**
+   * True if `input` needs an admin co-signature before it can be
+   * submitted — see `sendHighValuePayment`. Scoped deliberately narrowly
+   * for now: only plain native-XLM payments (no custom asset, no path
+   * payment) are gated, and only when `ADMIN_SIGNING_SECRET` is
+   * configured at all. Custom-asset and path-payment amounts aren't
+   * gated yet — a known limitation, not a silent gap, since extending the
+   * gate to those requires deciding what "value" means across assets
+   * (a price oracle), which is out of scope here.
+   */
+  private isHighValuePayment(
+    input: SendPaymentInput,
+    quote: PathQuote | undefined,
+  ): boolean {
+    if (!this.adminSigningSecret() || quote || input.assetCode) {
+      return false;
+    }
+    return Number(input.amount) > Number(this.highValueThresholdAmount());
+  }
+
+  /**
+   * Handles a payment above the high-value threshold: lazily configures
+   * the account for multisig on its first high-value payment (adds the
+   * platform's admin key as a co-signer, sets thresholds — see
+   * `@mixmatch/stellar`'s `configureMultisig`), builds a payment
+   * transaction that requires both signatures to authorize, signs it with
+   * only the account's own key, and persists it as `PENDING_SIGNATURE`
+   * *without* submitting. An admin must explicitly approve (co-sign and
+   * submit) or reject it — see `approvePendingSignature`/`rejectPendingSignature`.
+   */
+  private async sendHighValuePayment(
+    account: StellarAccountRecord,
+    input: SendPaymentInput,
+    idempotencyKey: string,
+  ): Promise<TransactionRecord> {
+    const existing =
+      await this.transactionRepository.findByIdempotencyKey(idempotencyKey);
+    if (existing) {
+      return existing;
+    }
+
+    let currentAccount = account;
+    if (!currentAccount.multisigConfigured) {
+      const wallet = this.walletForAccount(currentAccount);
+      await configureMultisig({
+        client: this.stellarClient,
+        wallet,
+        adminPublicKey: this.adminWallet().publicKey,
+      });
+      currentAccount =
+        await this.stellarAccountRepository.markMultisigConfigured(
+          currentAccount.id,
+        );
+    }
+
+    const wallet = this.walletForAccount(currentAccount);
+    const { envelopeXdr } = await buildHighValuePaymentEnvelope({
+      client: this.stellarClient,
+      sourceWallet: wallet,
+      destinationPublicKey: input.destinationPublicKey,
+      amount: input.amount,
+      memo: input.memo,
+    });
+
+    try {
+      return await this.transactionRepository.create({
+        idempotencyKey,
+        stellarAccountId: currentAccount.id,
+        destinationPublicKey: input.destinationPublicKey,
+        amount: input.amount,
+        memo: input.memo,
+        pendingEnvelopeXdr: envelopeXdr,
+      });
+    } catch (error) {
+      if (error instanceof DuplicateIdempotencyKeyError) {
+        const raced =
+          await this.transactionRepository.findByIdempotencyKey(idempotencyKey);
+        if (raced) {
+          return raced;
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Approves a `PENDING_SIGNATURE` transaction: co-signs its stored
+   * envelope with the admin key and submits it. Admin-only — see
+   * `modules/payments/admin.controller.ts`.
+   */
+  async approvePendingSignature(
+    transactionId: string,
+  ): Promise<TransactionRecord> {
+    const transaction =
+      await this.getPendingSignatureTransaction(transactionId);
+
+    try {
+      const result = await coSignAndSubmitEnvelope({
+        client: this.stellarClient,
+        envelopeXdr: transaction.pendingEnvelopeXdr as string,
+        adminWallet: this.adminWallet(),
+      });
+      return await this.transactionRepository.updateStatus(transaction.id, {
+        status: 'SUCCESS',
+        stellarTxHash: result.hash,
+        clearPendingEnvelope: true,
+      });
+    } catch (error) {
+      const classified =
+        error instanceof StellarPaymentError
+          ? error
+          : classifyStellarPaymentError(error);
+      await this.transactionRepository.updateStatus(transaction.id, {
+        status: 'FAILED',
+        failureCode: classified.kind,
+        failureReason: classified.message,
+        clearPendingEnvelope: true,
+      });
+      throw new PaymentFailedError(classified.kind, classified.message);
+    }
+  }
+
+  /**
+   * Rejects a `PENDING_SIGNATURE` transaction: marks it `FAILED` without
+   * ever attempting submission (the envelope, missing the admin's
+   * signature, was never valid to submit anyway). Admin-only.
+   */
+  async rejectPendingSignature(
+    transactionId: string,
+  ): Promise<TransactionRecord> {
+    const transaction =
+      await this.getPendingSignatureTransaction(transactionId);
+    return this.transactionRepository.updateStatus(transaction.id, {
+      status: 'FAILED',
+      failureCode: 'admin_rejected',
+      failureReason: 'An administrator declined to co-sign this payment',
+      clearPendingEnvelope: true,
+    });
+  }
+
+  /** Admin-facing: every transaction currently awaiting a co-signature, across all users. */
+  async listPendingSignatures(): Promise<TransactionRecord[]> {
+    return this.transactionRepository.findPendingSignature();
+  }
+
+  private async getPendingSignatureTransaction(
+    transactionId: string,
+  ): Promise<TransactionRecord> {
+    const transaction =
+      await this.transactionRepository.findById(transactionId);
+    if (!transaction) {
+      throw new NotFoundException('Transaction not found');
+    }
+    if (
+      transaction.status !== 'PENDING_SIGNATURE' ||
+      !transaction.pendingEnvelopeXdr
+    ) {
+      throw new PaymentFailedError(
+        'malformed_transaction',
+        `Transaction ${transactionId} is not awaiting a signature`,
+      );
+    }
+    return transaction;
+  }
+
+  private walletForAccount(account: StellarAccountRecord): KeypairWallet {
+    return KeypairWallet.fromSecret(
+      account.network,
+      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
+    );
+  }
+
+  private adminWallet(): KeypairWallet {
+    return KeypairWallet.fromSecret(
+      this.stellarClient.getNetwork(),
+      this.adminSigningSecretOrThrow(),
+    );
+  }
+
+  private adminSigningSecret(): string | undefined {
+    return this.configService.get<string>('adminSigningSecret');
+  }
+
+  private adminSigningSecretOrThrow(): string {
+    return this.configService.getOrThrow<string>('adminSigningSecret');
+  }
+
+  private highValueThresholdAmount(): string {
+    return this.configService.getOrThrow<string>('highValueThresholdAmount');
   }
 
   /**

--- a/apps/api/src/modules/payments/reconciliation.job.spec.ts
+++ b/apps/api/src/modules/payments/reconciliation.job.spec.ts
@@ -19,6 +19,7 @@ function buildTransaction(
     receiveAssetCode: null,
     receiveAssetIssuer: null,
     destAmount: null,
+    pendingEnvelopeXdr: null,
     status: 'SUCCESS',
     stellarTxHash: 'hash',
     failureCode: null,

--- a/apps/api/src/modules/payments/stellar-account.repository.ts
+++ b/apps/api/src/modules/payments/stellar-account.repository.ts
@@ -11,6 +11,7 @@ export interface StellarAccountRecord {
   publicKey: string;
   encryptedSecretKey: string;
   network: StellarNetwork;
+  multisigConfigured: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -49,6 +50,18 @@ export class StellarAccountRepository {
       .returning();
     if (!row) {
       throw new Error('Failed to create Stellar account');
+    }
+    return row;
+  }
+
+  async markMultisigConfigured(id: string): Promise<StellarAccountRecord> {
+    const [row] = await this.db
+      .update(schema.stellarAccounts)
+      .set({ multisigConfigured: true, updatedAt: new Date() })
+      .where(eq(schema.stellarAccounts.id, id))
+      .returning();
+    if (!row) {
+      throw new Error(`Stellar account not found: ${id}`);
     }
     return row;
   }

--- a/apps/api/src/modules/payments/transaction.repository.ts
+++ b/apps/api/src/modules/payments/transaction.repository.ts
@@ -31,6 +31,8 @@ export interface TransactionRecord {
   receiveAssetIssuer: string | null;
   /** Set only for a path payment: the exact amount the recipient receives. */
   destAmount: string | null;
+  /** Set only while status is PENDING_SIGNATURE, awaiting an admin co-signature. */
+  pendingEnvelopeXdr: string | null;
   status: TransactionStatus;
   stellarTxHash: string | null;
   failureCode: string | null;
@@ -79,6 +81,8 @@ export class TransactionRepository {
     receiveAssetCode?: string;
     receiveAssetIssuer?: string;
     destAmount?: string;
+    /** Set to create the row directly in PENDING_SIGNATURE, with the envelope awaiting co-signature. */
+    pendingEnvelopeXdr?: string;
   }): Promise<TransactionRecord> {
     try {
       const [row] = await this.db
@@ -91,7 +95,8 @@ export class TransactionRepository {
           receiveAssetCode: input.receiveAssetCode ?? null,
           receiveAssetIssuer: input.receiveAssetIssuer ?? null,
           destAmount: input.destAmount ?? null,
-          status: 'PENDING',
+          pendingEnvelopeXdr: input.pendingEnvelopeXdr ?? null,
+          status: input.pendingEnvelopeXdr ? 'PENDING_SIGNATURE' : 'PENDING',
         })
         .returning();
       if (!row) {
@@ -113,11 +118,18 @@ export class TransactionRepository {
       stellarTxHash?: string;
       failureCode?: string;
       failureReason?: string;
+      /** Pass true when resolving out of PENDING_SIGNATURE (approved or rejected) to clear the now-stale envelope. */
+      clearPendingEnvelope?: boolean;
     },
   ): Promise<TransactionRecord> {
+    const { clearPendingEnvelope, ...fields } = update;
     const [row] = await this.db
       .update(schema.transactions)
-      .set({ ...update, updatedAt: new Date() })
+      .set({
+        ...fields,
+        ...(clearPendingEnvelope ? { pendingEnvelopeXdr: null } : {}),
+        updatedAt: new Date(),
+      })
       .where(eq(schema.transactions.id, id))
       .returning();
     if (!row) {
@@ -146,6 +158,15 @@ export class TransactionRepository {
         .where(eq(schema.transactions.stellarAccountId, stellarAccountId)),
     ]);
     return { transactions: rows, total };
+  }
+
+  /** Admin-facing: every transaction awaiting a co-signature, across all users. */
+  async findPendingSignature(): Promise<TransactionRecord[]> {
+    return this.db
+      .select()
+      .from(schema.transactions)
+      .where(eq(schema.transactions.status, 'PENDING_SIGNATURE'))
+      .orderBy(desc(schema.transactions.createdAt));
   }
 
   async findStalePending(olderThan: Date): Promise<TransactionRecord[]> {

--- a/apps/api/src/modules/users/users.repository.ts
+++ b/apps/api/src/modules/users/users.repository.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import type { UserRole } from '@mixmatch/shared';
 import { eq } from 'drizzle-orm';
 import { DATABASE } from '../../db/db.module';
 import * as schema from '../../db/schema';
@@ -8,6 +9,7 @@ export interface User {
   id: string;
   email: string;
   passwordHash: string | null;
+  role: UserRole;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/apps/mobile/src/__tests__/useAuth.test.ts
+++ b/apps/mobile/src/__tests__/useAuth.test.ts
@@ -2,8 +2,17 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { useAuth } from '../hooks/useAuth';
 
-const AUTH: { user: { id: string; email: string; createdAt: string; updatedAt: string }; accessToken: string } = {
-  user: { id: '1', email: 'alice@test.com', createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' },
+const AUTH: {
+  user: { id: string; email: string; role: 'USER' | 'ADMIN'; createdAt: string; updatedAt: string };
+  accessToken: string;
+} = {
+  user: {
+    id: '1',
+    email: 'alice@test.com',
+    role: 'USER',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+  },
   accessToken: 'token-abc',
 };
 

--- a/apps/mobile/src/components/TransactionHistoryList.tsx
+++ b/apps/mobile/src/components/TransactionHistoryList.tsx
@@ -7,6 +7,7 @@ export interface TransactionHistoryListProps {
 
 const STATUS_COLOR: Record<TransactionRecord['status'], string> = {
   PENDING: '#b8860b',
+  PENDING_SIGNATURE: '#8860b8',
   SUCCESS: '#0a0',
   FAILED: '#e00',
   NEEDS_REVIEW: '#a05a00',

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -2,9 +2,12 @@
  * Shared authentication types used across the API, web, and mobile apps.
  */
 
+export type UserRole = 'USER' | 'ADMIN';
+
 export interface AuthUser {
   id: string;
   email: string;
+  role: UserRole;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/shared/src/types/payments.ts
+++ b/packages/shared/src/types/payments.ts
@@ -4,8 +4,13 @@
  * Horizon was unreachable for the whole escalation window), so the outcome
  * is genuinely unknown rather than a confirmed failure. It needs a human
  * to check the ledger directly.
+ *
+ * `PENDING_SIGNATURE` is for a payment above the high-value threshold: the
+ * caller's own signature is on file, but an admin co-signature is still
+ * required before it can be submitted to the network. See
+ * `@mixmatch/stellar`'s `buildHighValuePaymentEnvelope`/`configureMultisig`.
  */
-export type TransactionStatus = 'PENDING' | 'SUCCESS' | 'FAILED' | 'NEEDS_REVIEW';
+export type TransactionStatus = 'PENDING' | 'PENDING_SIGNATURE' | 'SUCCESS' | 'FAILED' | 'NEEDS_REVIEW';
 
 export interface TransactionRecord {
   id: string;
@@ -45,6 +50,11 @@ export interface TransactionHistoryResponse {
   total: number;
   page: number;
   limit: number;
+}
+
+/** Admin-facing: transactions awaiting a co-signature, across all users. */
+export interface PendingSignatureTransactionsResponse {
+  transactions: TransactionRecord[];
 }
 
 export interface StellarAccountResponse {

--- a/packages/stellar/src/__tests__/multisig.test.ts
+++ b/packages/stellar/src/__tests__/multisig.test.ts
@@ -1,0 +1,148 @@
+import { Keypair, Transaction } from '@stellar/stellar-sdk';
+import { describe, expect, it, vi } from 'vitest';
+import { StellarPaymentError } from '../payment-errors.js';
+import { buildHighValuePaymentEnvelope, coSignAndSubmitEnvelope, configureMultisig } from '../multisig.js';
+import { KeypairWallet } from '../wallet.js';
+import { fakeAccount, fakeClient } from './test-helpers.js';
+
+describe('configureMultisig', () => {
+  it('submits a setOptions operation adding the admin signer and setting thresholds', async () => {
+    const sourceKeypair = Keypair.random();
+    const adminPublicKey = Keypair.random().publicKey();
+    const submitTransaction = vi.fn().mockResolvedValue({ hash: 'config-hash', ledger: 10 });
+    const client = fakeClient({ loadAccount: () => fakeAccount(sourceKeypair), submitTransaction });
+    const wallet = KeypairWallet.fromSecret('testnet', sourceKeypair.secret());
+
+    const result = await configureMultisig({ client, wallet, adminPublicKey });
+
+    expect(result.hash).toBe('config-hash');
+    const submittedTx = submitTransaction.mock.calls[0]?.[0];
+    const op = submittedTx.operations[0];
+    expect(op.type).toBe('setOptions');
+    expect(op.signer.ed25519PublicKey).toBe(adminPublicKey);
+    expect(op.signer.weight).toBe(1);
+    expect(op.masterWeight).toBe(1);
+    expect(op.lowThreshold).toBe(1);
+    expect(op.medThreshold).toBe(1);
+    expect(op.highThreshold).toBe(2);
+  });
+
+  it('wraps a submission failure as a StellarPaymentError', async () => {
+    const sourceKeypair = Keypair.random();
+    const client = fakeClient({
+      loadAccount: () => fakeAccount(sourceKeypair),
+      submitTransaction: () => Promise.reject(new Error('network down')),
+    });
+    const wallet = KeypairWallet.fromSecret('testnet', sourceKeypair.secret());
+
+    await expect(
+      configureMultisig({ client, wallet, adminPublicKey: Keypair.random().publicKey() }),
+    ).rejects.toBeInstanceOf(StellarPaymentError);
+  });
+});
+
+describe('buildHighValuePaymentEnvelope', () => {
+  it('builds a payment + masterWeight-asserting setOptions operation, signed only by the source wallet', async () => {
+    const sourceKeypair = Keypair.random();
+    const client = fakeClient({ loadAccount: () => fakeAccount(sourceKeypair) });
+    const wallet = KeypairWallet.fromSecret('testnet', sourceKeypair.secret());
+    const destination = Keypair.random().publicKey();
+
+    const { envelopeXdr } = await buildHighValuePaymentEnvelope({
+      client,
+      sourceWallet: wallet,
+      destinationPublicKey: destination,
+      amount: '500',
+    });
+
+    const transaction = new Transaction(envelopeXdr, client.networkPassphrase);
+    expect(transaction.operations).toHaveLength(2);
+    expect(transaction.operations[0]?.type).toBe('payment');
+    expect(transaction.operations[1]?.type).toBe('setOptions');
+    expect((transaction.operations[1] as { masterWeight?: number }).masterWeight).toBe(1);
+    expect(transaction.signatures).toHaveLength(1);
+  });
+
+  it('includes a memo when provided', async () => {
+    const sourceKeypair = Keypair.random();
+    const client = fakeClient({ loadAccount: () => fakeAccount(sourceKeypair) });
+    const wallet = KeypairWallet.fromSecret('testnet', sourceKeypair.secret());
+
+    const { envelopeXdr } = await buildHighValuePaymentEnvelope({
+      client,
+      sourceWallet: wallet,
+      destinationPublicKey: Keypair.random().publicKey(),
+      amount: '500',
+      memo: 'high-value-1',
+    });
+
+    const transaction = new Transaction(envelopeXdr, client.networkPassphrase);
+    expect(transaction.memo.value?.toString()).toBe('high-value-1');
+  });
+
+  it('wraps a load-account failure as a StellarPaymentError', async () => {
+    const client = fakeClient({ loadAccount: () => Promise.reject(new Error('not found')) });
+    const wallet = KeypairWallet.fromSecret('testnet', Keypair.random().secret());
+
+    await expect(
+      buildHighValuePaymentEnvelope({
+        client,
+        sourceWallet: wallet,
+        destinationPublicKey: Keypair.random().publicKey(),
+        amount: '500',
+      }),
+    ).rejects.toBeInstanceOf(StellarPaymentError);
+  });
+});
+
+describe('coSignAndSubmitEnvelope', () => {
+  it('adds the admin signature and submits', async () => {
+    const sourceKeypair = Keypair.random();
+    const adminKeypair = Keypair.random();
+    const client = fakeClient({ loadAccount: () => fakeAccount(sourceKeypair) });
+    const sourceWallet = KeypairWallet.fromSecret('testnet', sourceKeypair.secret());
+    const adminWallet = KeypairWallet.fromSecret('testnet', adminKeypair.secret());
+
+    const { envelopeXdr } = await buildHighValuePaymentEnvelope({
+      client,
+      sourceWallet,
+      destinationPublicKey: Keypair.random().publicKey(),
+      amount: '500',
+    });
+
+    const submitTransaction = vi.fn().mockResolvedValue({ hash: 'final-hash', ledger: 20 });
+    const submittingClient = fakeClient({ submitTransaction });
+
+    const result = await coSignAndSubmitEnvelope({ client: submittingClient, envelopeXdr, adminWallet });
+
+    expect(result.hash).toBe('final-hash');
+    const submittedTx: Transaction = submitTransaction.mock.calls[0]?.[0];
+    expect(submittedTx.signatures).toHaveLength(2);
+  });
+
+  it('wraps a submission failure (e.g. only one signature present) as a StellarPaymentError', async () => {
+    const sourceKeypair = Keypair.random();
+    const client = fakeClient({ loadAccount: () => fakeAccount(sourceKeypair) });
+    const sourceWallet = KeypairWallet.fromSecret('testnet', sourceKeypair.secret());
+
+    const { envelopeXdr } = await buildHighValuePaymentEnvelope({
+      client,
+      sourceWallet,
+      destinationPublicKey: Keypair.random().publicKey(),
+      amount: '500',
+    });
+
+    const submittingClient = fakeClient({
+      submitTransaction: () =>
+        Promise.reject(new Error('tx_failed: op_bad_auth')),
+    });
+
+    await expect(
+      coSignAndSubmitEnvelope({
+        client: submittingClient,
+        envelopeXdr,
+        adminWallet: KeypairWallet.fromSecret('testnet', Keypair.random().secret()),
+      }),
+    ).rejects.toBeInstanceOf(StellarPaymentError);
+  });
+});

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -13,3 +13,4 @@ export * from './path-payment.js';
 export * from './sep/sep1.js';
 export * from './sep/sep10.js';
 export * from './sep/sep24.js';
+export * from './multisig.js';

--- a/packages/stellar/src/multisig.ts
+++ b/packages/stellar/src/multisig.ts
@@ -1,0 +1,147 @@
+import { Asset, BASE_FEE, Memo, Operation, Transaction, TransactionBuilder } from '@stellar/stellar-sdk';
+import type { DefaultStellarClient } from './client.js';
+import { classifyStellarPaymentError } from './payment-errors.js';
+import type { StellarPaymentResult } from './payment.js';
+import type { StellarAssetRef } from './types/index.js';
+import type { Wallet } from './wallet.js';
+
+const TRANSACTION_TIMEOUT_SECONDS = 30;
+
+/**
+ * Weight assigned to both the account's own key and the admin co-signer.
+ * Regular operations (medium threshold, weight 1) still succeed with just
+ * the account's own signature. A transaction that also carries a
+ * high-threshold operation (weight 2) needs both signatures combined.
+ */
+const SIGNER_WEIGHT = 1;
+const LOW_THRESHOLD = 1;
+const MED_THRESHOLD = 1;
+const HIGH_THRESHOLD = 2;
+
+export interface ConfigureMultisigParams {
+  client: DefaultStellarClient;
+  /** The account being upgraded to require a co-signature for high-value payments. */
+  wallet: Wallet;
+  /** The platform's admin co-signing key's public key. */
+  adminPublicKey: string;
+}
+
+/**
+ * One-time, per-account setup: adds the platform's admin key as an
+ * additional signer and sets thresholds so that regular payments (medium
+ * threshold) still only need the account's own signature, but a
+ * transaction carrying a high-threshold operation needs both signatures
+ * combined. See `buildHighValuePaymentEnvelope` for how that's forced for
+ * a specific payment.
+ */
+export async function configureMultisig(params: ConfigureMultisigParams): Promise<StellarPaymentResult> {
+  try {
+    const sourceAccount = await params.client.horizon.loadAccount(params.wallet.publicKey);
+
+    const transaction = new TransactionBuilder(sourceAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: params.client.networkPassphrase,
+    })
+      .addOperation(
+        Operation.setOptions({
+          signer: { ed25519PublicKey: params.adminPublicKey, weight: SIGNER_WEIGHT },
+          masterWeight: SIGNER_WEIGHT,
+          lowThreshold: LOW_THRESHOLD,
+          medThreshold: MED_THRESHOLD,
+          highThreshold: HIGH_THRESHOLD,
+        }),
+      )
+      .setTimeout(TRANSACTION_TIMEOUT_SECONDS)
+      .build();
+
+    transaction.sign(params.wallet.getKeypair());
+
+    const result = await params.client.horizon.submitTransaction(transaction);
+    return { hash: result.hash, ledger: result.ledger };
+  } catch (error) {
+    throw classifyStellarPaymentError(error);
+  }
+}
+
+export interface BuildHighValuePaymentEnvelopeParams {
+  client: DefaultStellarClient;
+  sourceWallet: Wallet;
+  destinationPublicKey: string;
+  amount: string;
+  asset?: StellarAssetRef;
+  memo?: string;
+}
+
+/**
+ * Builds a payment transaction that requires the account's *high*
+ * threshold to authorize, by including a `setOptions` operation alongside
+ * the payment that re-asserts the account's current `masterWeight`.
+ * `setOptions` only requires high threshold when it touches a
+ * signer/weight/threshold field — an empty `setOptions{}` is classified
+ * as medium and does *not* force it (verified against testnet: a
+ * single-signature submission succeeded when the accompanying operation
+ * had no fields set). Re-asserting the unchanged `masterWeight` is a
+ * genuine no-op for account state, but the field being *present* is what
+ * triggers the high-threshold check — so a transaction containing it
+ * needs the combined weight of both signers (see `configureMultisig`).
+ * Signs with the account's own key only and returns the
+ * (partially-signed) envelope XDR — the caller persists this and submits
+ * only once an admin has co-signed it via `coSignAndSubmitEnvelope`.
+ */
+export async function buildHighValuePaymentEnvelope(
+  params: BuildHighValuePaymentEnvelopeParams,
+): Promise<{ envelopeXdr: string }> {
+  try {
+    const sourceAccount = await params.client.horizon.loadAccount(params.sourceWallet.publicKey);
+
+    const builder = new TransactionBuilder(sourceAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: params.client.networkPassphrase,
+    })
+      .addOperation(
+        Operation.payment({
+          destination: params.destinationPublicKey,
+          asset: params.asset ? new Asset(params.asset.code, params.asset.issuer) : Asset.native(),
+          amount: params.amount,
+        }),
+      )
+      // No-op: forces this transaction to require the high threshold.
+      // Re-asserts the unchanged masterWeight set by configureMultisig —
+      // see the doc comment above for why this (and not an empty
+      // setOptions{}) is what forces the high-threshold requirement.
+      .addOperation(Operation.setOptions({ masterWeight: SIGNER_WEIGHT }));
+
+    if (params.memo) {
+      builder.addMemo(Memo.text(params.memo));
+    }
+
+    const transaction = builder.setTimeout(TRANSACTION_TIMEOUT_SECONDS).build();
+    transaction.sign(params.sourceWallet.getKeypair());
+
+    return { envelopeXdr: transaction.toXDR() };
+  } catch (error) {
+    throw classifyStellarPaymentError(error);
+  }
+}
+
+export interface CoSignAndSubmitEnvelopeParams {
+  client: DefaultStellarClient;
+  envelopeXdr: string;
+  /** The platform's admin co-signing wallet. */
+  adminWallet: Wallet;
+}
+
+/** Adds the admin's signature to a previously-built high-value payment envelope and submits it. */
+export async function coSignAndSubmitEnvelope(
+  params: CoSignAndSubmitEnvelopeParams,
+): Promise<StellarPaymentResult> {
+  try {
+    const transaction = new Transaction(params.envelopeXdr, params.client.networkPassphrase);
+    transaction.sign(params.adminWallet.getKeypair());
+
+    const result = await params.client.horizon.submitTransaction(transaction);
+    return { hash: result.hash, ledger: result.ledger };
+  } catch (error) {
+    throw classifyStellarPaymentError(error);
+  }
+}


### PR DESCRIPTION
Introduces a high-value payment flow that stores partially signed transactions as `PENDING_SIGNATURE`, requires admin co-sign approval/rejection endpoints, and adds Stellar multisig helpers (`configureMultisig`, envelope build, co-sign submit) with coverage. Adds role-based auth support (user roles in schema/shared types, JWT role claim, `Roles` decorator/guard) plus migration and repository updates for `users.role`, `stellar_accounts.multisig_configured`, and `transactions.pending_envelope_xdr`, with mobile/shared status handling updated accordingly.

closes #860 