### PR TITLE
Add SSE transaction streaming and JWT fallback

### DIFF
--- a/apps/api/src/modules/auth/jwt-auth.guard.spec.ts
+++ b/apps/api/src/modules/auth/jwt-auth.guard.spec.ts
@@ -1,0 +1,100 @@
+import { UnauthorizedException } from '@nestjs/common';
+import type { ExecutionContext } from '@nestjs/common';
+import type { JwtService } from '@nestjs/jwt';
+import { JwtAuthGuard } from './jwt-auth.guard';
+import type { AuthenticatedRequest } from './jwt-auth.guard';
+
+function buildContext(
+  request: Partial<AuthenticatedRequest>,
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+}
+
+describe('JwtAuthGuard', () => {
+  it('authenticates via the Authorization header', () => {
+    const jwtService = {
+      verify: jest.fn().mockReturnValue({ sub: 'user-1', role: 'USER' }),
+    };
+    const guard = new JwtAuthGuard(jwtService as unknown as JwtService);
+    const request: Partial<AuthenticatedRequest> = {
+      headers: { authorization: 'Bearer header-token' },
+      query: {},
+    };
+
+    expect(guard.canActivate(buildContext(request))).toBe(true);
+    expect(jwtService.verify).toHaveBeenCalledWith('header-token');
+    expect(request.userId).toBe('user-1');
+    expect(request.userRole).toBe('USER');
+  });
+
+  it('falls back to a ?token= query param when no Authorization header is present (for EventSource)', () => {
+    const jwtService = {
+      verify: jest.fn().mockReturnValue({ sub: 'user-1', role: 'ADMIN' }),
+    };
+    const guard = new JwtAuthGuard(jwtService as unknown as JwtService);
+    const request: Partial<AuthenticatedRequest> = {
+      headers: {},
+      query: { token: 'query-token' },
+    };
+
+    expect(guard.canActivate(buildContext(request))).toBe(true);
+    expect(jwtService.verify).toHaveBeenCalledWith('query-token');
+    expect(request.userId).toBe('user-1');
+  });
+
+  it('prefers the Authorization header over a query token when both are present', () => {
+    const jwtService = { verify: jest.fn().mockReturnValue({ sub: 'user-1' }) };
+    const guard = new JwtAuthGuard(jwtService as unknown as JwtService);
+    const request: Partial<AuthenticatedRequest> = {
+      headers: { authorization: 'Bearer header-token' },
+      query: { token: 'query-token' },
+    };
+
+    guard.canActivate(buildContext(request));
+
+    expect(jwtService.verify).toHaveBeenCalledWith('header-token');
+  });
+
+  it('throws when neither a header nor a query token is present', () => {
+    const jwtService = { verify: jest.fn() };
+    const guard = new JwtAuthGuard(jwtService as unknown as JwtService);
+    const request: Partial<AuthenticatedRequest> = { headers: {}, query: {} };
+
+    expect(() => guard.canActivate(buildContext(request))).toThrow(
+      UnauthorizedException,
+    );
+    expect(jwtService.verify).not.toHaveBeenCalled();
+  });
+
+  it('throws when the token is invalid or expired', () => {
+    const jwtService = {
+      verify: jest.fn().mockImplementation(() => {
+        throw new Error('expired');
+      }),
+    };
+    const guard = new JwtAuthGuard(jwtService as unknown as JwtService);
+    const request: Partial<AuthenticatedRequest> = {
+      headers: { authorization: 'Bearer bad-token' },
+      query: {},
+    };
+
+    expect(() => guard.canActivate(buildContext(request))).toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('throws when the token has no subject claim', () => {
+    const jwtService = { verify: jest.fn().mockReturnValue({}) };
+    const guard = new JwtAuthGuard(jwtService as unknown as JwtService);
+    const request: Partial<AuthenticatedRequest> = {
+      headers: { authorization: 'Bearer token' },
+      query: {},
+    };
+
+    expect(() => guard.canActivate(buildContext(request))).toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/apps/api/src/modules/auth/jwt-auth.guard.ts
+++ b/apps/api/src/modules/auth/jwt-auth.guard.ts
@@ -27,13 +27,21 @@ export class JwtAuthGuard implements CanActivate {
     const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
     const header = request.headers.authorization;
 
-    if (!header?.startsWith('Bearer ')) {
+    // EventSource (used for the SSE transaction stream) can't set custom
+    // headers, so it authenticates via a `?token=` query param instead.
+    // Only used as a fallback when there's no Authorization header — a
+    // normal request with a bad/missing header still 401s as before.
+    const queryToken =
+      typeof request.query.token === 'string' ? request.query.token : undefined;
+    const token = header?.startsWith('Bearer ')
+      ? header.slice('Bearer '.length)
+      : queryToken;
+
+    if (!token) {
       throw new UnauthorizedException(
         'Missing or invalid Authorization header',
       );
     }
-
-    const token = header.slice('Bearer '.length);
 
     try {
       const payload = this.jwtService.verify<JwtPayload>(token);

--- a/apps/api/src/modules/payments/payments.controller.ts
+++ b/apps/api/src/modules/payments/payments.controller.ts
@@ -2,10 +2,12 @@ import {
   Body,
   Controller,
   Get,
+  MessageEvent,
   NotFoundException,
   Param,
   Post,
   Query,
+  Sse,
   UseGuards,
   UsePipes,
 } from '@nestjs/common';
@@ -20,6 +22,7 @@ import {
   type SendPaymentInput,
   type StellarAccountResponse,
 } from '@mixmatch/shared';
+import { map, type Observable } from 'rxjs';
 import { ZodValidationPipe } from '../../common/zod-validation.pipe';
 import { CurrentUserId } from '../auth/current-user.decorator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -60,6 +63,22 @@ export class PaymentsController {
     const account =
       await this.paymentsService.getOrCreateStellarAccount(userId);
     return { publicKey: account.publicKey, network: account.network };
+  }
+
+  /**
+   * Server-Sent Events stream of the caller's transaction status changes,
+   * pushed the moment Horizon's payment stream reports them — an
+   * alternative to polling `GET /:id/status`. Authenticates via
+   * `?token=` since `EventSource` can't set an Authorization header (see
+   * `JwtAuthGuard`). Clients should keep polling as a fallback if the
+   * stream connection can't be established at all; once connected, the
+   * underlying Horizon stream reconnects on its own after a drop.
+   */
+  @Sse('stream')
+  stream(@CurrentUserId() userId: string): Observable<MessageEvent> {
+    return this.paymentsService
+      .streamTransactionUpdates(userId)
+      .pipe(map((transaction) => ({ data: { transaction } })));
   }
 
   @Get('history')

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -72,6 +72,31 @@ const coSignAndSubmitEnvelopeMock = jest.fn<
   Parameters<CoSignAndSubmitEnvelopeFn>
 >();
 
+interface FakeStreamEvent {
+  type: string;
+  to?: string;
+  amount?: string;
+  assetType?: string;
+  assetCode?: string;
+  assetIssuer?: string;
+  transactionHash: string;
+  createdAt: string;
+}
+
+interface FakeStreamParams {
+  accountPublicKey: string;
+  onEvent: (event: FakeStreamEvent) => void;
+}
+
+type StreamAccountPaymentsFn = (params: FakeStreamParams) => {
+  close: () => void;
+};
+
+const streamAccountPaymentsMock = jest.fn<
+  { close: () => void },
+  Parameters<StreamAccountPaymentsFn>
+>();
+
 jest.mock('@mixmatch/stellar', () => {
   const actual: object = jest.requireActual('@mixmatch/stellar');
   const establishTrustline: EstablishTrustlineFn = (input) =>
@@ -89,6 +114,8 @@ jest.mock('@mixmatch/stellar', () => {
   ) => buildHighValuePaymentEnvelopeMock(input);
   const coSignAndSubmitEnvelope: CoSignAndSubmitEnvelopeFn = (input) =>
     coSignAndSubmitEnvelopeMock(input);
+  const streamAccountPayments: StreamAccountPaymentsFn = (params) =>
+    streamAccountPaymentsMock(params);
   return {
     ...actual,
     establishTrustline,
@@ -98,6 +125,7 @@ jest.mock('@mixmatch/stellar', () => {
     configureMultisig,
     buildHighValuePaymentEnvelope,
     coSignAndSubmitEnvelope,
+    streamAccountPayments,
   };
 });
 import { encryptSecretKey } from './wallet-encryption';
@@ -138,6 +166,10 @@ function buildAccount(
     updatedAt: new Date(),
     ...overrides,
   };
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
 }
 
 function buildTransaction(
@@ -184,6 +216,7 @@ describe('PaymentsService', () => {
     configureMultisigMock.mockReset();
     buildHighValuePaymentEnvelopeMock.mockReset();
     coSignAndSubmitEnvelopeMock.mockReset();
+    streamAccountPaymentsMock.mockReset();
     stellarAccountRepository = {
       findByUserId: jest.fn(),
       findById: jest.fn(),
@@ -197,6 +230,7 @@ describe('PaymentsService', () => {
       updateStatus: jest.fn(),
       listByStellarAccountId: jest.fn(),
       findStalePending: jest.fn(),
+      findPendingByStellarAccountId: jest.fn().mockResolvedValue([]),
     };
     paymentEngine = { submitPayment: jest.fn() };
     stellarClient = {
@@ -735,6 +769,137 @@ describe('PaymentsService', () => {
       const result = await service.listPendingSignatures();
 
       expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('streamTransactionUpdates', () => {
+    it('completes without starting a Horizon stream when the caller has no Stellar account yet', async () => {
+      stellarAccountRepository.findByUserId.mockResolvedValue(null);
+
+      const events: TransactionRecord[] = [];
+      let completed = false;
+      service.streamTransactionUpdates('user-1').subscribe({
+        next: (t) => events.push(t),
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      await flushMicrotasks();
+
+      expect(completed).toBe(true);
+      expect(events).toEqual([]);
+      expect(streamAccountPaymentsMock).not.toHaveBeenCalled();
+    });
+
+    it('starts a Horizon stream for the account and emits the matched transaction on a matching event', async () => {
+      stellarAccountRepository.findByUserId.mockResolvedValue(buildAccount());
+      transactionRepository.findPendingByStellarAccountId.mockResolvedValue([
+        buildTransaction({
+          id: 'tx-1',
+          destinationPublicKey: 'GDEST',
+          amount: '10.0000000',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ]);
+      transactionRepository.updateStatus.mockResolvedValue(
+        buildTransaction({
+          id: 'tx-1',
+          status: 'SUCCESS',
+          stellarTxHash: 'stream-hash',
+        }),
+      );
+      const closeMock = jest.fn();
+      streamAccountPaymentsMock.mockImplementation((params) => {
+        setTimeout(() => {
+          params.onEvent({
+            type: 'payment',
+            to: 'GDEST',
+            amount: '10.0000000',
+            assetType: 'native',
+            transactionHash: 'stream-hash',
+            createdAt: '2026-01-01T00:01:00.000Z',
+          });
+        }, 0);
+        return { close: closeMock };
+      });
+
+      const events: TransactionRecord[] = [];
+      const subscription = service
+        .streamTransactionUpdates('user-1')
+        .subscribe((t) => events.push(t));
+
+      await flushMicrotasks();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await flushMicrotasks();
+
+      expect(streamAccountPaymentsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ accountPublicKey: 'GABCDEF' }),
+      );
+      expect(transactionRepository.updateStatus).toHaveBeenCalledWith(
+        'tx-1',
+        expect.objectContaining({
+          status: 'SUCCESS',
+          stellarTxHash: 'stream-hash',
+        }),
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]?.status).toBe('SUCCESS');
+
+      subscription.unsubscribe();
+      expect(closeMock).toHaveBeenCalled();
+    });
+
+    it('does not update or emit anything for an event that matches no pending transaction', async () => {
+      stellarAccountRepository.findByUserId.mockResolvedValue(buildAccount());
+      transactionRepository.findPendingByStellarAccountId.mockResolvedValue([
+        buildTransaction({
+          id: 'tx-1',
+          destinationPublicKey: 'GDEST',
+          amount: '10.0000000',
+        }),
+      ]);
+      streamAccountPaymentsMock.mockImplementation((params) => {
+        setTimeout(() => {
+          params.onEvent({
+            type: 'payment',
+            to: 'GDEST',
+            amount: '999.0000000',
+            assetType: 'native',
+            transactionHash: 'unrelated-hash',
+            createdAt: '2026-01-01T00:01:00.000Z',
+          });
+        }, 0);
+        return { close: jest.fn() };
+      });
+
+      const events: TransactionRecord[] = [];
+      const subscription = service
+        .streamTransactionUpdates('user-1')
+        .subscribe((t) => events.push(t));
+
+      await flushMicrotasks();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await flushMicrotasks();
+
+      expect(transactionRepository.updateStatus).not.toHaveBeenCalled();
+      expect(events).toEqual([]);
+      subscription.unsubscribe();
+    });
+
+    it('closes the underlying Horizon stream when the caller unsubscribes', async () => {
+      stellarAccountRepository.findByUserId.mockResolvedValue(buildAccount());
+      const closeMock = jest.fn();
+      streamAccountPaymentsMock.mockReturnValue({ close: closeMock });
+
+      const subscription = service
+        .streamTransactionUpdates('user-1')
+        .subscribe();
+      await flushMicrotasks();
+
+      subscription.unsubscribe();
+
+      expect(closeMock).toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -19,9 +19,13 @@ import {
   KeypairWallet,
   StellarPaymentError,
   StellarPaymentService as StellarPaymentEngine,
+  streamAccountPayments,
   submitPathPayment,
   type PathQuote,
+  type PaymentStreamEvent,
+  type PaymentStreamHandle,
 } from '@mixmatch/stellar';
+import { Observable } from 'rxjs';
 import type {
   EstablishTrustlineInput,
   EstablishTrustlineResponse,
@@ -722,6 +726,97 @@ export class PaymentsService {
       'asset_issuer' in operation &&
       operation.asset_issuer === expectedIssuer
     );
+  }
+
+  /**
+   * Pushes a transaction's status the moment Horizon's payment stream for
+   * the caller's account reports it — an alternative to `getTransactionStatus`
+   * polling. Bridged to clients over SSE, see `PaymentsController`'s
+   * `stream` route. Completes if the caller has no Stellar account yet;
+   * otherwise stays open until the subscriber unsubscribes (client
+   * disconnects), at which point the underlying Horizon stream — which
+   * reconnects on its own using the last-seen event's cursor, see
+   * `@mixmatch/stellar`'s `streamAccountPayments` — is torn down too.
+   */
+  streamTransactionUpdates(userId: string): Observable<TransactionRecord> {
+    return new Observable<TransactionRecord>((subscriber) => {
+      let unsubscribed = false;
+      let handle: PaymentStreamHandle | undefined;
+
+      void this.stellarAccountRepository.findByUserId(userId).then(
+        (account) => {
+          if (unsubscribed) {
+            return;
+          }
+          if (!account) {
+            subscriber.complete();
+            return;
+          }
+
+          handle = streamAccountPayments({
+            client: this.stellarClient,
+            accountPublicKey: account.publicKey,
+            onEvent: (event) => {
+              void this.resolveStreamEvent(account.id, event)
+                .then((updated) => {
+                  if (updated && !unsubscribed) {
+                    subscriber.next(updated);
+                  }
+                })
+                .catch((error: unknown) => subscriber.error(error));
+            },
+          });
+        },
+        (error: unknown) => subscriber.error(error),
+      );
+
+      return () => {
+        unsubscribed = true;
+        handle?.close();
+      };
+    });
+  }
+
+  /** Checks a single streamed Horizon event against the account's still-PENDING transactions, updating and returning the one it matches, if any. */
+  private async resolveStreamEvent(
+    stellarAccountId: string,
+    event: PaymentStreamEvent,
+  ): Promise<TransactionRecord | null> {
+    if (!MATCHABLE_OPERATION_TYPES.has(event.type)) {
+      return null;
+    }
+
+    const pending =
+      await this.transactionRepository.findPendingByStellarAccountId(
+        stellarAccountId,
+      );
+    const expectedAmount = event.amount
+      ? Number(event.amount).toFixed(7)
+      : undefined;
+
+    const match = pending.find((transaction) => {
+      const pseudoOperation = {
+        asset_type: event.assetType,
+        asset_code: event.assetCode,
+        asset_issuer: event.assetIssuer,
+      };
+      return (
+        this.matchesTransactionAsset(pseudoOperation, transaction) &&
+        event.to === transaction.destinationPublicKey &&
+        expectedAmount ===
+          normalizeAmount(transaction.destAmount ?? transaction.amount) &&
+        new Date(event.createdAt) >= transaction.createdAt
+      );
+    });
+
+    if (!match) {
+      return null;
+    }
+
+    return this.transactionRepository.updateStatus(match.id, {
+      status: 'SUCCESS',
+      stellarTxHash: event.transactionHash,
+    });
   }
 
   private reconciliationStaleMs(): number {

--- a/apps/api/src/modules/payments/transaction.repository.ts
+++ b/apps/api/src/modules/payments/transaction.repository.ts
@@ -169,6 +169,21 @@ export class TransactionRepository {
       .orderBy(desc(schema.transactions.createdAt));
   }
 
+  /** Every PENDING transaction for one account — used to match against live Horizon stream events, see PaymentsService.streamTransactionUpdates. */
+  async findPendingByStellarAccountId(
+    stellarAccountId: string,
+  ): Promise<TransactionRecord[]> {
+    return this.db
+      .select()
+      .from(schema.transactions)
+      .where(
+        and(
+          eq(schema.transactions.stellarAccountId, stellarAccountId),
+          eq(schema.transactions.status, 'PENDING'),
+        ),
+      );
+  }
+
   async findStalePending(olderThan: Date): Promise<TransactionRecord[]> {
     return this.db
       .select()

--- a/apps/mobile/src/__tests__/payments-client.test.ts
+++ b/apps/mobile/src/__tests__/payments-client.test.ts
@@ -4,7 +4,23 @@ import {
   getTransactionStatus,
   reconcileTransaction,
   sendPayment,
+  subscribeToTransactionStream,
 } from '../services/payments-client';
+
+function sseBodyStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let index = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (index >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(chunks[index]));
+      index += 1;
+    },
+  });
+}
 
 describe('payments-client', () => {
   let fetchMock: jest.Mock;
@@ -54,5 +70,84 @@ describe('payments-client', () => {
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toContain('/payments/tx-1/reconcile');
     expect(init.method).toBe('POST');
+  });
+});
+
+describe('subscribeToTransactionStream', () => {
+  it('authenticates via a ?token= query param and parses SSE events into transaction updates', async () => {
+    const transaction = { id: 'tx-1', status: 'SUCCESS' };
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      body: sseBodyStream([`data: ${JSON.stringify({ transaction })}\n\n`]),
+    }) as unknown as typeof fetch;
+
+    const onTransaction = jest.fn();
+    const onError = jest.fn();
+    const handle = subscribeToTransactionStream('tok', onTransaction, onError);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onTransaction).toHaveBeenCalledWith(transaction);
+    expect(onError).not.toHaveBeenCalled();
+
+    const [url] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    expect(url).toContain('/payments/stream?token=tok');
+
+    handle.close();
+  });
+
+  it('parses multiple SSE events split across chunks', async () => {
+    const first = { id: 'tx-1', status: 'PENDING' };
+    const second = { id: 'tx-1', status: 'SUCCESS' };
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      body: sseBodyStream([
+        `data: ${JSON.stringify({ transaction: first })}\n\n`,
+        `data: ${JSON.stringify({ transaction: second })}\n\n`,
+      ]),
+    }) as unknown as typeof fetch;
+
+    const onTransaction = jest.fn();
+    const handle = subscribeToTransactionStream('tok', onTransaction);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onTransaction).toHaveBeenCalledTimes(2);
+    expect(onTransaction).toHaveBeenNthCalledWith(1, first);
+    expect(onTransaction).toHaveBeenNthCalledWith(2, second);
+
+    handle.close();
+  });
+
+  it('calls onError when the stream request fails', async () => {
+    globalThis.fetch = jest.fn().mockResolvedValue({ ok: false, status: 401, body: null }) as unknown as typeof fetch;
+
+    const onError = jest.fn();
+    const handle = subscribeToTransactionStream('bad-token', jest.fn(), onError);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    handle.close();
+  });
+
+  it('does not call onError after close() even if the underlying request later rejects', async () => {
+    let rejectFetch!: (error: unknown) => void;
+    globalThis.fetch = jest.fn().mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectFetch = reject;
+      }),
+    ) as unknown as typeof fetch;
+
+    const onError = jest.fn();
+    const handle = subscribeToTransactionStream('tok', jest.fn(), onError);
+    handle.close();
+    rejectFetch(new Error('aborted'));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/components/PaymentsScreen.tsx
+++ b/apps/mobile/src/components/PaymentsScreen.tsx
@@ -7,6 +7,7 @@ import {
   getTransactionHistory,
   quotePath,
   sendPayment,
+  subscribeToTransactionStream,
 } from '../services/payments-client';
 import MyQrCode from './MyQrCode';
 import QrScanner from './QrScanner';
@@ -29,6 +30,7 @@ export default function PaymentsScreen() {
   const [scannedDestination, setScannedDestination] = useState<string | undefined>(undefined);
   const [transactions, setTransactions] = useState<TransactionRecord[]>([]);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+  const [streamAvailable, setStreamAvailable] = useState(true);
 
   const loadAccount = useCallback(async () => {
     if (!accessToken) return;
@@ -56,6 +58,41 @@ export default function PaymentsScreen() {
       void loadHistory();
     }
   }, [tab, loadHistory]);
+
+  // Real-time transaction status: subscribe once per session rather than
+  // per tab-visit, so an in-flight payment updates even while the user is
+  // elsewhere in the app. Falls back to the existing tab-focus poll above
+  // (and a slow background poll below) if the stream can't be opened.
+  useEffect(() => {
+    if (!accessToken) return;
+
+    const handle = subscribeToTransactionStream(
+      accessToken,
+      (transaction) => {
+        setStreamAvailable(true);
+        setTransactions((prev) => {
+          const index = prev.findIndex((existing) => existing.id === transaction.id);
+          if (index === -1) {
+            return [transaction, ...prev];
+          }
+          const next = [...prev];
+          next[index] = transaction;
+          return next;
+        });
+      },
+      () => setStreamAvailable(false),
+    );
+
+    return () => handle.close();
+  }, [accessToken]);
+
+  // Fallback only: re-poll periodically while viewing history if the
+  // stream connection isn't available, so status updates still arrive.
+  useEffect(() => {
+    if (streamAvailable || tab !== 'history') return;
+    const interval = setInterval(() => void loadHistory(), 15_000);
+    return () => clearInterval(interval);
+  }, [streamAvailable, tab, loadHistory]);
 
   const handleScanned = (data: string) => {
     setScannedDestination(data);

--- a/apps/mobile/src/services/api-client.ts
+++ b/apps/mobile/src/services/api-client.ts
@@ -1,4 +1,4 @@
-const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
+export const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
 
 export class ApiError extends Error {
   code?: string;

--- a/apps/mobile/src/services/payments-client.ts
+++ b/apps/mobile/src/services/payments-client.ts
@@ -7,9 +7,10 @@ import type {
   SendPaymentResponse,
   StellarAccountResponse,
   TransactionHistoryResponse,
+  TransactionRecord,
   TransactionStatusResponse,
 } from '@mixmatch/shared';
-import { authHeaders, request } from './api-client';
+import { API_URL, authHeaders, request } from './api-client';
 
 export function sendPayment(input: SendPaymentInput, accessToken: string): Promise<SendPaymentResponse> {
   return request<SendPaymentResponse>('/payments/send', {
@@ -74,4 +75,80 @@ export function quotePath(input: PathQuoteInput, accessToken: string): Promise<P
     headers: authHeaders(accessToken),
     body: JSON.stringify(input),
   });
+}
+
+export interface TransactionStreamHandle {
+  close: () => void;
+}
+
+/**
+ * Subscribes to `GET /payments/stream` (Server-Sent Events) for real-time
+ * transaction status updates, instead of polling `getTransactionStatus`.
+ * Authenticates via `?token=` in the URL since `fetch`/`EventSource` can't
+ * attach a custom Authorization header to an SSE request.
+ *
+ * Requires the runtime's `fetch` to support streaming response bodies
+ * (`response.body` as a `ReadableStream`) — true on recent Hermes/React
+ * Native, but not guaranteed on every device. If the stream can't be
+ * opened or drops permanently, `onError` fires; callers should fall back
+ * to polling `getTransactionStatus`/`getTransactionHistory` in that case
+ * rather than assume the stream will recover on its own.
+ */
+export function subscribeToTransactionStream(
+  accessToken: string,
+  onTransaction: (transaction: TransactionRecord) => void,
+  onError?: (error: unknown) => void,
+): TransactionStreamHandle {
+  const controller = new AbortController();
+  let closed = false;
+
+  void (async () => {
+    try {
+      const response = await fetch(`${API_URL}/payments/stream?token=${encodeURIComponent(accessToken)}`, {
+        headers: { Accept: 'text/event-stream' },
+        signal: controller.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error(`Transaction stream request failed: HTTP ${response.status}`);
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (!closed) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        buffer += decoder.decode(value, { stream: true });
+
+        let boundary = buffer.indexOf('\n\n');
+        while (boundary !== -1) {
+          const rawEvent = buffer.slice(0, boundary);
+          buffer = buffer.slice(boundary + 2);
+          const dataLine = rawEvent.split('\n').find((line) => line.startsWith('data:'));
+          if (dataLine) {
+            const payload = JSON.parse(dataLine.slice('data:'.length).trim()) as {
+              transaction: TransactionRecord;
+            };
+            onTransaction(payload.transaction);
+          }
+          boundary = buffer.indexOf('\n\n');
+        }
+      }
+    } catch (error) {
+      if (!closed) {
+        onError?.(error);
+      }
+    }
+  })();
+
+  return {
+    close: () => {
+      closed = true;
+      controller.abort();
+    },
+  };
 }

--- a/packages/stellar/src/__tests__/streaming.test.ts
+++ b/packages/stellar/src/__tests__/streaming.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { streamAccountPayments } from '../streaming.js';
+import type { DefaultStellarClient } from '../client.js';
+
+interface FakeStreamOptions {
+  onmessage: (raw: unknown) => void;
+  onerror: (error: unknown) => void;
+}
+
+function fakeStreamingClient() {
+  const closeMocks: Array<ReturnType<typeof vi.fn>> = [];
+  const capturedOptions: FakeStreamOptions[] = [];
+  const cursorCalls: string[] = [];
+  const forAccountMock = vi.fn();
+
+  const client = {
+    horizon: {
+      payments: vi.fn().mockReturnValue({ forAccount: forAccountMock }),
+    },
+  } as unknown as DefaultStellarClient;
+
+  forAccountMock.mockImplementation(() => {
+    const builder = {
+      order: vi.fn().mockReturnThis(),
+      cursor: vi.fn((token: string) => {
+        cursorCalls.push(token);
+        return builder;
+      }),
+      stream: vi.fn((options: FakeStreamOptions) => {
+        capturedOptions.push(options);
+        const closeMock = vi.fn();
+        closeMocks.push(closeMock);
+        return closeMock;
+      }),
+    };
+    return builder;
+  });
+
+  return { client, capturedOptions, closeMocks, cursorCalls };
+}
+
+describe('streamAccountPayments', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts a live stream (no cursor) when none is provided', () => {
+    const { client, cursorCalls } = fakeStreamingClient();
+
+    const handle = streamAccountPayments({
+      client,
+      accountPublicKey: 'GACCOUNT',
+      onEvent: () => {},
+    });
+
+    expect(cursorCalls).toEqual([]);
+    handle.close();
+  });
+
+  it('starts from the provided cursor', () => {
+    const { client, cursorCalls } = fakeStreamingClient();
+
+    const handle = streamAccountPayments({
+      client,
+      accountPublicKey: 'GACCOUNT',
+      cursor: 'existing-cursor',
+      onEvent: () => {},
+    });
+
+    expect(cursorCalls).toEqual(['existing-cursor']);
+    handle.close();
+  });
+
+  it('normalizes an incoming raw Horizon record to camelCase and forwards it to onEvent', () => {
+    const { client, capturedOptions } = fakeStreamingClient();
+    const onEvent = vi.fn();
+
+    const handle = streamAccountPayments({ client, accountPublicKey: 'GACCOUNT', onEvent });
+
+    capturedOptions[0]?.onmessage({
+      id: 'event-1',
+      paging_token: 'token-1',
+      type: 'payment',
+      to: 'GDEST',
+      from: 'GSOURCE',
+      amount: '10.0000000',
+      asset_type: 'native',
+      transaction_hash: 'hash-1',
+      created_at: '2026-01-01T00:00:00Z',
+    });
+
+    expect(onEvent).toHaveBeenCalledWith({
+      id: 'event-1',
+      pagingToken: 'token-1',
+      type: 'payment',
+      to: 'GDEST',
+      from: 'GSOURCE',
+      amount: '10.0000000',
+      assetType: 'native',
+      assetCode: undefined,
+      assetIssuer: undefined,
+      transactionHash: 'hash-1',
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    handle.close();
+  });
+
+  it('on error, reconnects from the paging token of the last event actually delivered, not from "now"', () => {
+    vi.useFakeTimers();
+    const { client, capturedOptions, cursorCalls } = fakeStreamingClient();
+    const onEvent = vi.fn();
+    const onError = vi.fn();
+
+    const handle = streamAccountPayments({
+      client,
+      accountPublicKey: 'GACCOUNT',
+      onEvent,
+      onError,
+      reconnectDelayMs: 1000,
+    });
+
+    // First connection delivers one event, then errors (connection dropped).
+    capturedOptions[0]?.onmessage({
+      id: 'event-1',
+      paging_token: 'token-1',
+      type: 'payment',
+      transaction_hash: 'hash-1',
+      created_at: '2026-01-01T00:00:00Z',
+    });
+    capturedOptions[0]?.onerror(new Event('error'));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    // Not yet reconnected — still waiting out reconnectDelayMs.
+    expect(cursorCalls).toEqual([]);
+
+    vi.advanceTimersByTime(1000);
+
+    // Reconnected using the paging token of the last delivered event, so
+    // nothing that landed during the gap is silently skipped.
+    expect(cursorCalls).toEqual(['token-1']);
+    expect(capturedOptions).toHaveLength(2);
+
+    handle.close();
+  });
+
+  it('keeps advancing the reconnect cursor across multiple delivered events before a drop', () => {
+    vi.useFakeTimers();
+    const { client, capturedOptions, cursorCalls } = fakeStreamingClient();
+
+    const handle = streamAccountPayments({
+      client,
+      accountPublicKey: 'GACCOUNT',
+      onEvent: () => {},
+      reconnectDelayMs: 500,
+    });
+
+    capturedOptions[0]?.onmessage({
+      id: 'event-1',
+      paging_token: 'token-1',
+      type: 'payment',
+      transaction_hash: 'hash-1',
+      created_at: '2026-01-01T00:00:00Z',
+    });
+    capturedOptions[0]?.onmessage({
+      id: 'event-2',
+      paging_token: 'token-2',
+      type: 'payment',
+      transaction_hash: 'hash-2',
+      created_at: '2026-01-01T00:00:01Z',
+    });
+    capturedOptions[0]?.onerror(new Event('error'));
+    vi.advanceTimersByTime(500);
+
+    expect(cursorCalls).toEqual(['token-2']);
+    handle.close();
+  });
+
+  it('stops reconnecting once closed, even if a reconnect was already scheduled', () => {
+    vi.useFakeTimers();
+    const { client, capturedOptions, closeMocks } = fakeStreamingClient();
+
+    const handle = streamAccountPayments({
+      client,
+      accountPublicKey: 'GACCOUNT',
+      onEvent: () => {},
+      reconnectDelayMs: 500,
+    });
+
+    capturedOptions[0]?.onerror(new Event('error'));
+    handle.close();
+    vi.advanceTimersByTime(500);
+
+    expect(capturedOptions).toHaveLength(1);
+    expect(closeMocks[0]).toHaveBeenCalled();
+  });
+});

--- a/packages/stellar/src/index.ts
+++ b/packages/stellar/src/index.ts
@@ -14,3 +14,4 @@ export * from './sep/sep1.js';
 export * from './sep/sep10.js';
 export * from './sep/sep24.js';
 export * from './multisig.js';
+export * from './streaming.js';

--- a/packages/stellar/src/streaming.ts
+++ b/packages/stellar/src/streaming.ts
@@ -1,0 +1,119 @@
+import type { DefaultStellarClient } from './client.js';
+
+export interface PaymentStreamEvent {
+  id: string;
+  /** Horizon's paging token for this event — pass as `cursor` to resume a stream from just after it. */
+  pagingToken: string;
+  type: string;
+  to?: string;
+  from?: string;
+  amount?: string;
+  assetType?: string;
+  assetCode?: string;
+  assetIssuer?: string;
+  transactionHash: string;
+  createdAt: string;
+}
+
+interface RawPaymentRecord {
+  id: string;
+  paging_token: string;
+  type: string;
+  to?: string;
+  from?: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  transaction_hash: string;
+  created_at: string;
+}
+
+function toPaymentStreamEvent(raw: RawPaymentRecord): PaymentStreamEvent {
+  return {
+    id: raw.id,
+    pagingToken: raw.paging_token,
+    type: raw.type,
+    to: raw.to,
+    from: raw.from,
+    amount: raw.amount,
+    assetType: raw.asset_type,
+    assetCode: raw.asset_code,
+    assetIssuer: raw.asset_issuer,
+    transactionHash: raw.transaction_hash,
+    createdAt: raw.created_at,
+  };
+}
+
+export interface StreamAccountPaymentsParams {
+  client: DefaultStellarClient;
+  accountPublicKey: string;
+  /**
+   * Resume from just after this paging token instead of starting live —
+   * pass the `pagingToken` of the last event you actually processed (e.g.
+   * from a client's `Last-Event-ID`) so a reconnect never silently misses
+   * events that landed during the gap.
+   */
+  cursor?: string;
+  onEvent: (event: PaymentStreamEvent) => void;
+  onError?: (error: unknown) => void;
+  /** Delay before reconnecting after a stream error, in ms. Defaults to 5000. */
+  reconnectDelayMs?: number;
+}
+
+export interface PaymentStreamHandle {
+  /** Stops the stream and cancels any pending reconnect. */
+  close: () => void;
+}
+
+/**
+ * Wraps Horizon's SSE payment stream for one account with automatic,
+ * cursor-based reconnection: on a stream error, it reconnects starting
+ * just after the last event actually delivered to `onEvent`, rather than
+ * from "now" — so a dropped connection never silently drops events that
+ * landed during the gap.
+ */
+export function streamAccountPayments(params: StreamAccountPaymentsParams): PaymentStreamHandle {
+  let closed = false;
+  let lastPagingToken = params.cursor;
+  let closeCurrentStream: (() => void) | undefined;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function connect(): void {
+    if (closed) {
+      return;
+    }
+
+    let callBuilder = params.client.horizon.payments().forAccount(params.accountPublicKey).order('asc');
+    if (lastPagingToken) {
+      callBuilder = callBuilder.cursor(lastPagingToken);
+    }
+
+    closeCurrentStream = callBuilder.stream({
+      onmessage: (raw: unknown) => {
+        const event = toPaymentStreamEvent(raw as RawPaymentRecord);
+        lastPagingToken = event.pagingToken;
+        params.onEvent(event);
+      },
+      onerror: (error: unknown) => {
+        params.onError?.(error);
+        closeCurrentStream?.();
+        if (!closed) {
+          reconnectTimer = setTimeout(connect, params.reconnectDelayMs ?? 5000);
+        }
+      },
+    });
+  }
+
+  connect();
+
+  return {
+    close: () => {
+      closed = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+      }
+      closeCurrentStream?.();
+    },
+  };
+}


### PR DESCRIPTION
Add end-to-end Server-Sent-Events transaction streaming support. Introduce packages/stellar/src/streaming.ts (streamAccountPayments) with reconnect-on-error semantics and tests, and export it from the stellar index. Add PaymentsService.streamTransactionUpdates and resolveStreamEvent to match Horizon events to pending transactions, plus TransactionRepository.findPendingByStellarAccountId. Add PaymentsController @Sse('stream') endpoint. Update JwtAuthGuard to accept ?token= fallback for EventSource. Add mobile-side subscribeToTransactionStream, UI integration in PaymentsScreen, and related tests. Misc: export API_URL from api-client and add unit tests for guards and streaming behavior.

closes #861 