### PR TITLE
Add Vault KMS & WalletResolver for Vault signing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,9 +42,31 @@ RECONCILIATION_ESCALATION_MS=86400000
 ANCHOR_HOME_DOMAIN=testanchor.stellar.org
 
 # High-value payment co-signing (apps/api/src/modules/payments/payments.service.ts,
-# @mixmatch/stellar's multisig.ts). Leave ADMIN_SIGNING_SECRET unset to disable
-# the gate entirely — payments proceed regardless of amount, as before this
-# feature existed. Set it to a funded Stellar secret key to turn it on.
+# @mixmatch/stellar's multisig.ts). Leave both ADMIN_SIGNING_SECRET and
+# ADMIN_SIGNING_KEY_NAME unset to disable the gate entirely — payments
+# proceed regardless of amount, as before this feature existed.
+# - No Vault configured below: set ADMIN_SIGNING_SECRET to a funded Stellar
+#   secret key to turn the gate on.
+# - Vault configured below: set ADMIN_SIGNING_KEY_NAME instead, to the name
+#   of a funded Vault transit key (ADMIN_SIGNING_SECRET is ignored).
 ADMIN_SIGNING_SECRET=
+ADMIN_SIGNING_KEY_NAME=
 # Native-XLM amount above which a payment requires admin co-signature.
 HIGH_VALUE_THRESHOLD_AMOUNT=1000
+
+# HashiCorp Vault (transit secrets engine) — the KMS backend for Stellar
+# account signing keys (see @mixmatch/kms, apps/api/src/modules/payments/
+# wallet-resolver.ts, and apps/api/src/modules/payments/README.md's "Wallet
+# custody" section). Leave VAULT_ADDR unset to keep using the legacy
+# WALLET_ENCRYPTION_KEY-encrypted-secret path for every new account (e.g.
+# local dev without Vault installed) — existing accounts on that path keep
+# working regardless of this setting.
+#
+# Local dev quickstart:
+#   vault server -dev -dev-root-token-id=root
+#   export VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=root
+#   vault secrets enable transit
+#   vault write -f transit/keys/platform-admin type=ed25519
+VAULT_ADDR=
+VAULT_TOKEN=
+VAULT_TRANSIT_MOUNT_PATH=transit

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@mixmatch/kms": "workspace:*",
     "@mixmatch/shared": "workspace:*",
     "@mixmatch/stellar": "workspace:*",
     "@nestjs/common": "^11.0.1",

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -29,6 +29,28 @@ export interface EnvConfig {
   adminSigningSecret?: string;
   /** Native-XLM amount above which a payment requires admin co-signature; only enforced if `adminSigningSecret` is set. */
   highValueThresholdAmount: string;
+  /**
+   * Address of the HashiCorp Vault server whose transit secrets engine
+   * holds Stellar account signing keys (see `@mixmatch/kms`'s
+   * VaultTransitClient and modules/payments/wallet-resolver.ts). Set
+   * together with `vaultToken` to move new-account signing off the
+   * `walletEncryptionKey` symmetric-key model entirely — key material for
+   * every new account then never exists outside Vault, not even
+   * transiently in this process. Left unset, new accounts fall back to
+   * the legacy encrypted-secret path (e.g. local dev without Vault
+   * installed); existing accounts on that path keep working regardless.
+   */
+  vaultAddr?: string;
+  /** Vault token authorized for the transit mount's create/read/sign paths. Required if `vaultAddr` is set. */
+  vaultToken?: string;
+  /** Vault transit mount path. Defaults to "transit". */
+  vaultTransitMountPath?: string;
+  /**
+   * Name of the platform's admin co-signing key inside Vault, used in
+   * place of `adminSigningSecret` once Vault is configured. Required if
+   * `vaultAddr` is set and the high-value-payment gate is used.
+   */
+  adminSigningKeyName?: string;
 }
 
 const DEFAULT_PORT = 3000;
@@ -71,6 +93,12 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): EnvConfig {
   const stellarNetwork =
     env.STELLAR_NETWORK?.trim() === 'public' ? 'public' : 'testnet';
 
+  const vaultAddr = env.VAULT_ADDR?.trim() || undefined;
+  const vaultToken = env.VAULT_TOKEN?.trim() || undefined;
+  if (vaultAddr && !vaultToken) {
+    throw new Error('VAULT_TOKEN is required when VAULT_ADDR is set');
+  }
+
   return {
     nodeEnv,
     port: Number(env.PORT) || DEFAULT_PORT,
@@ -97,5 +125,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): EnvConfig {
     highValueThresholdAmount:
       env.HIGH_VALUE_THRESHOLD_AMOUNT?.trim() ||
       DEFAULT_HIGH_VALUE_THRESHOLD_AMOUNT,
+    vaultAddr,
+    vaultToken,
+    vaultTransitMountPath: env.VAULT_TRANSIT_MOUNT_PATH?.trim() || undefined,
+    adminSigningKeyName: env.ADMIN_SIGNING_KEY_NAME?.trim() || undefined,
   };
 }

--- a/apps/api/src/db/migrations/0007_wonderful_nocturne.sql
+++ b/apps/api/src/db/migrations/0007_wonderful_nocturne.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "stellar_accounts" ALTER COLUMN "encrypted_secret_key" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "stellar_accounts" ADD COLUMN "signing_key_id" text;

--- a/apps/api/src/db/migrations/meta/0007_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,857 @@
+{
+  "id": "50d2d469-ef33-41d2-b5d1-c8f14f1a4129",
+  "prevId": "5b5259a8-f6de-49b5-a2dd-bfcbb6cc2dd3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.anchor_transactions": {
+      "name": "anchor_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stellar_account_id": {
+          "name": "stellar_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "anchor_transaction_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_code": {
+          "name": "asset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_domain": {
+          "name": "home_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sep24_transaction_id": {
+          "name": "sep24_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "anchor_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interactive_url": {
+          "name": "interactive_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "more_info_url": {
+          "name": "more_info_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_in": {
+          "name": "amount_in",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_out": {
+          "name": "amount_out",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stellar_transaction_id": {
+          "name": "stellar_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_transaction_id": {
+          "name": "external_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "anchor_transactions_stellar_account_id_stellar_accounts_id_fk": {
+          "name": "anchor_transactions_stellar_account_id_stellar_accounts_id_fk",
+          "tableFrom": "anchor_transactions",
+          "tableTo": "stellar_accounts",
+          "columnsFrom": [
+            "stellar_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "anchor_transactions_sep24_transaction_id_unique": {
+          "name": "anchor_transactions_sep24_transaction_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sep24_transaction_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.escrows": {
+      "name": "escrows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_stellar_account_id": {
+          "name": "payer_stellar_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payee_public_key": {
+          "name": "payee_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_contract_id": {
+          "name": "token_contract_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "on_chain_escrow_id": {
+          "name": "on_chain_escrow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout_ledger": {
+          "name": "timeout_ledger",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "escrow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "deposit_tx_hash": {
+          "name": "deposit_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalize_tx_hash": {
+          "name": "finalize_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "escrows_payer_stellar_account_id_stellar_accounts_id_fk": {
+          "name": "escrows_payer_stellar_account_id_stellar_accounts_id_fk",
+          "tableFrom": "escrows",
+          "tableTo": "stellar_accounts",
+          "columnsFrom": [
+            "payer_stellar_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "escrows_idempotency_key_unique": {
+          "name": "escrows_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stellar_accounts": {
+      "name": "stellar_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_secret_key": {
+          "name": "encrypted_secret_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "stellar_network",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'testnet'"
+        },
+        "multisig_configured": {
+          "name": "multisig_configured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stellar_accounts_user_id_users_id_fk": {
+          "name": "stellar_accounts_user_id_users_id_fk",
+          "tableFrom": "stellar_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stellar_accounts_user_id_unique": {
+          "name": "stellar_accounts_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "stellar_accounts_public_key_unique": {
+          "name": "stellar_accounts_public_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.streaming_connections": {
+      "name": "streaming_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "streaming_connections_user_id_users_id_fk": {
+          "name": "streaming_connections_user_id_users_id_fk",
+          "tableFrom": "streaming_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taste_profiles": {
+      "name": "taste_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acousticness": {
+          "name": "acousticness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "danceability": {
+          "name": "danceability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "energy": {
+          "name": "energy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valence": {
+          "name": "valence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_ingested_at": {
+          "name": "last_ingested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "taste_profiles_user_id_users_id_fk": {
+          "name": "taste_profiles_user_id_users_id_fk",
+          "tableFrom": "taste_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stellar_account_id": {
+          "name": "stellar_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_public_key": {
+          "name": "destination_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_code": {
+          "name": "asset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "asset_issuer": {
+          "name": "asset_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_asset_code": {
+          "name": "receive_asset_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receive_asset_issuer": {
+          "name": "receive_asset_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dest_amount": {
+          "name": "dest_amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_envelope_xdr": {
+          "name": "pending_envelope_xdr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "stellar_tx_hash": {
+          "name": "stellar_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_stellar_account_id_stellar_accounts_id_fk": {
+          "name": "transactions_stellar_account_id_stellar_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "stellar_accounts",
+          "columnsFrom": [
+            "stellar_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transactions_idempotency_key_unique": {
+          "name": "transactions_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USER'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.anchor_transaction_kind": {
+      "name": "anchor_transaction_kind",
+      "schema": "public",
+      "values": [
+        "deposit",
+        "withdrawal"
+      ]
+    },
+    "public.anchor_transaction_status": {
+      "name": "anchor_transaction_status",
+      "schema": "public",
+      "values": [
+        "incomplete",
+        "pending_user_transfer_start",
+        "pending_user_transfer_complete",
+        "pending_external",
+        "pending_anchor",
+        "pending_stellar",
+        "pending_trust",
+        "pending_user",
+        "on_hold",
+        "completed",
+        "refunded",
+        "expired",
+        "error"
+      ]
+    },
+    "public.escrow_status": {
+      "name": "escrow_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "LOCKED",
+        "RELEASED",
+        "REFUNDED",
+        "FAILED"
+      ]
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": [
+        "spotify",
+        "apple_music"
+      ]
+    },
+    "public.stellar_network": {
+      "name": "stellar_network",
+      "schema": "public",
+      "values": [
+        "testnet",
+        "public"
+      ]
+    },
+    "public.transaction_status": {
+      "name": "transaction_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "PENDING_SIGNATURE",
+        "SUCCESS",
+        "FAILED",
+        "NEEDS_REVIEW"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "USER",
+        "ADMIN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1787653676570,
       "tag": "0006_grey_masque",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1787691685177,
+      "tag": "0007_wonderful_nocturne",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -107,9 +107,18 @@ export const stellarAccounts = pgTable('stellar_accounts', {
     .unique()
     .notNull(),
   publicKey: text('public_key').unique().notNull(),
-  // AES-256-GCM ciphertext of the account's Stellar secret key, see
-  // modules/payments/wallet-encryption.ts. Never stored in plaintext.
-  encryptedSecretKey: text('encrypted_secret_key').notNull(),
+  // Legacy key-custody path: AES-256-GCM ciphertext of the account's
+  // Stellar secret key (modules/payments/wallet-encryption.ts). Null for
+  // every account created after the Vault/KMS migration — exactly one of
+  // encryptedSecretKey/signingKeyId is set, enforced at the application
+  // layer (see modules/payments/wallet-resolver.ts), since Drizzle has no
+  // portable XOR column constraint.
+  encryptedSecretKey: text('encrypted_secret_key'),
+  // Name of this account's ed25519 signing key inside Vault's transit
+  // secrets engine (see @mixmatch/kms's VaultTransitClient). The actual
+  // key material never leaves Vault — this column is just a reference.
+  // Null for legacy accounts still on encryptedSecretKey.
+  signingKeyId: text('signing_key_id'),
   network: stellarNetworkEnum('network').default('testnet').notNull(),
   // True once the account has had the platform's admin key added as a
   // co-signer and thresholds configured (see multisig.ts's

--- a/apps/api/src/modules/payments/README.md
+++ b/apps/api/src/modules/payments/README.md
@@ -1,0 +1,41 @@
+# Payments module
+
+## Wallet custody
+
+Every custodial Stellar account (`stellar_accounts` row) is signed one of two ways:
+
+- **Vault-backed (`signingKeyId`)** — every account created while `VAULT_ADDR`/`VAULT_TOKEN` are configured. The account's ed25519 keypair lives entirely inside HashiCorp Vault's transit secrets engine, created with `exportable: false` / `allow_plaintext_backup: false` — the private key material never leaves Vault, not even transiently in this process. Signing a transaction means sending its hash to Vault and getting a signature back (`@mixmatch/kms`'s `VaultTransitClient`); this process only ever holds the account's *public* key.
+- **Locally-encrypted secret (`encryptedSecretKey`), legacy** — every account created before this migration, or created now if Vault isn't configured (e.g. local dev without Vault installed). The Stellar secret key is encrypted at rest with AES-256-GCM under one shared `WALLET_ENCRYPTION_KEY` and decrypted into memory for the duration of a single signing operation (`wallet-encryption.ts`). Kept working indefinitely — never migrated automatically — but no longer used for new accounts.
+
+`stellar_accounts` has exactly one of `signingKeyId` / `encryptedSecretKey` set per row; this is enforced at the application layer (`WalletResolver`), not as a DB constraint, since Drizzle doesn't have a portable XOR check across nullable columns.
+
+[`wallet-resolver.ts`](./wallet-resolver.ts)'s `WalletResolver` is the single chokepoint every service (`PaymentsService`, `EscrowService`, `AnchorService`) goes through to get a signing `Wallet` for an account or for the platform's admin co-signer — no service constructs a `KeypairWallet`/`VaultWallet` directly. It dispatches on:
+
+- `walletForAccount(account)` — `VaultWallet` if `signingKeyId` is set, else legacy `KeypairWallet`.
+- `createAccountSigner()` — used only by `PaymentsService.getOrCreateStellarAccount` when provisioning a brand-new account. Creates a Vault transit key if Vault is configured, otherwise falls back to generating and encrypting a local keypair.
+- `adminWallet()` — the platform's high-value-payment co-signer (see multisig, issue #860): a Vault key (`ADMIN_SIGNING_KEY_NAME`) if Vault is configured, otherwise the legacy `ADMIN_SIGNING_SECRET`.
+
+### Why Vault/KMS over client-side non-custodial signing
+
+This is a custodial wallet platform — the server has always held signing authority on the user's behalf (that's what made the pre-existing `WALLET_ENCRYPTION_KEY` design a real liability: one symmetric key, compromised once, decrypts every account's secret key, for every account, forever). Two ways to remove that single point of failure were considered:
+
+1. **KMS/HSM-backed signing service (chosen)** — move signing keys out of this process into a dedicated key-management system (HashiCorp Vault's transit engine, backed by a real dev-mode server for this implementation and verified end-to-end against it). The server still initiates and requests every signature, but the signing key itself never exists in this process's memory, and Vault's own access control/audit logging governs who can invoke a signature — a compromise of the API process's memory or the `WALLET_ENCRYPTION_KEY` env var no longer yields every user's key material at once.
+2. **Genuine non-custodial client-side signing** — the user's device holds the key and signs locally; the server never sees it at all. Rejected for this iteration: it's a materially different product (users must manage their own keys, install a wallet, handle backups/recovery themselves) and a much larger surface change across every payment flow (path payments, escrow, SEP-24 anchor auth, multisig) than a key-custody hardening pass. Worth revisiting as a future opt-in wallet-connect-style flow, but out of scope here.
+
+Vault-Stellar signature compatibility was verified empirically against a real running Vault dev server before writing any application code: Vault's raw 32-byte ed25519 public key converts directly to a Stellar `G...` address (`StrKey.encodeEd25519PublicKey`), and Vault's raw 64-byte signature over a transaction's hash verifies directly as a Stellar signature (`Keypair.verify`) — no protocol-level translation needed. `@stellar/stellar-sdk`'s `Transaction.prototype.addSignature` is the mechanism used to attach that externally-produced signature; it self-validates against the wallet's public key before appending, so a corrupted or mismatched remote signature throws immediately rather than producing a silently-invalid transaction.
+
+### Legacy accounts / migration scope
+
+Existing accounts created before this change keep using `encryptedSecretKey` indefinitely — there is no automatic re-keying into Vault. Migrating a live account's signing authority into Vault would require either (a) a transaction moving funds to a fresh Vault-backed account, or (b) importing the existing secret key into Vault (which reintroduces the exact plaintext-exposure moment this change is meant to eliminate, only once instead of on every use) — both are product/ops decisions belonging to a separate change, not silently bundled into this one. This is an explicit, intentional scope boundary, not an oversight.
+
+### Local Vault setup for development
+
+```bash
+vault server -dev -dev-root-token-id=root
+export VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=root
+vault secrets enable transit
+vault write -f transit/keys/platform-admin type=ed25519
+vault read -field=public_key transit/keys/platform-admin  # for funding via Friendbot/manually
+```
+
+Then set `VAULT_ADDR`, `VAULT_TOKEN`, and `ADMIN_SIGNING_KEY_NAME=platform-admin` in `.env` (see the repo-root `.env.example`). Leaving `VAULT_ADDR` unset keeps the legacy encrypted-secret path active for every new account, unchanged from before this migration.

--- a/apps/api/src/modules/payments/anchor.service.spec.ts
+++ b/apps/api/src/modules/payments/anchor.service.spec.ts
@@ -13,6 +13,7 @@ import {
   type StellarAccountRecord,
 } from './stellar-account.repository';
 import type { PaymentsService } from './payments.service';
+import { WalletResolver } from './wallet-resolver';
 
 const ENCRYPTION_KEY = 'ab'.repeat(32);
 const REAL_TESTNET_SECRET = Keypair.random().secret();
@@ -80,6 +81,7 @@ function buildAccount(
     userId: 'user-1',
     publicKey: 'GABCDEF',
     encryptedSecretKey: encryptSecretKey(REAL_TESTNET_SECRET, ENCRYPTION_KEY),
+    signingKeyId: null,
     network: 'testnet',
     multisigConfigured: false,
     createdAt: new Date(),
@@ -169,6 +171,11 @@ describe('AnchorService', () => {
     };
     paymentsService = { getOrCreateStellarAccount: jest.fn() };
 
+    const configService = {
+      getOrThrow: jest.fn((key: string) => CONFIG_VALUES[key]),
+      get: jest.fn((key: string) => CONFIG_VALUES[key]),
+    } as unknown as ConfigService;
+
     service = new AnchorService(
       anchorTransactionRepository as unknown as AnchorTransactionRepository,
       stellarAccountRepository as unknown as StellarAccountRepository,
@@ -176,9 +183,8 @@ describe('AnchorService', () => {
       {
         networkPassphrase: Networks.TESTNET,
       } as unknown as DefaultStellarClient,
-      {
-        getOrThrow: jest.fn((key: string) => CONFIG_VALUES[key]),
-      } as unknown as ConfigService,
+      configService,
+      new WalletResolver(configService),
     );
   });
 

--- a/apps/api/src/modules/payments/anchor.service.ts
+++ b/apps/api/src/modules/payments/anchor.service.ts
@@ -13,7 +13,6 @@ import {
   getSep24Transaction,
   initiateSep24Deposit,
   initiateSep24Withdraw,
-  KeypairWallet,
   SEP24_IN_PROGRESS_STATUSES,
   type Sep24Transaction,
 } from '@mixmatch/stellar';
@@ -23,13 +22,13 @@ import type {
   DepositAnchorInput,
   WithdrawAnchorInput,
 } from '@mixmatch/shared';
-import { decryptSecretKey } from './wallet-encryption';
 import { PaymentsService } from './payments.service';
 import {
   AnchorTransactionRepository,
   type AnchorTransactionRecord,
 } from './anchor-transaction.repository';
 import { StellarAccountRepository } from './stellar-account.repository';
+import { WalletResolver } from './wallet-resolver';
 
 /** Anchor unreachable, misconfigured (missing required SEP-1 fields), or rejected a SEP-10/SEP-24 call. */
 export class AnchorError extends HttpException {
@@ -50,6 +49,7 @@ export class AnchorService {
     private readonly paymentsService: PaymentsService,
     private readonly stellarClient: DefaultStellarClient,
     private readonly configService: ConfigService,
+    private readonly walletResolver: WalletResolver,
   ) {}
 
   /** Starts a SEP-24 interactive deposit — returns the anchor's interactive URL for the user to open and complete KYC/payment details. */
@@ -127,10 +127,7 @@ export class AnchorService {
       );
     }
 
-    const wallet = KeypairWallet.fromSecret(
-      account.network,
-      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
-    );
+    const wallet = await this.walletResolver.walletForAccount(account);
 
     try {
       const jwt = await authenticateSep10({
@@ -197,10 +194,7 @@ export class AnchorService {
       return transaction;
     }
 
-    const wallet = KeypairWallet.fromSecret(
-      account.network,
-      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
-    );
+    const wallet = await this.walletResolver.walletForAccount(account);
 
     const jwt = await authenticateSep10({
       webAuthEndpoint: toml.webAuthEndpoint,
@@ -250,10 +244,6 @@ export class AnchorService {
 
   private anchorHomeDomain(): string {
     return this.configService.getOrThrow<string>('anchorHomeDomain');
-  }
-
-  private walletEncryptionKey(): string {
-    return this.configService.getOrThrow<string>('walletEncryptionKey');
   }
 }
 

--- a/apps/api/src/modules/payments/escrow.service.spec.ts
+++ b/apps/api/src/modules/payments/escrow.service.spec.ts
@@ -17,6 +17,7 @@ import {
   type StellarAccountRecord,
 } from './stellar-account.repository';
 import type { PaymentsService } from './payments.service';
+import { WalletResolver } from './wallet-resolver';
 
 const ENCRYPTION_KEY = 'ab'.repeat(32);
 const REAL_TESTNET_SECRET = Keypair.random().secret();
@@ -115,6 +116,7 @@ function buildAccount(
     userId: 'user-1',
     publicKey: 'GABCDEF',
     encryptedSecretKey: encryptSecretKey(REAL_TESTNET_SECRET, ENCRYPTION_KEY),
+    signingKeyId: null,
     network: 'testnet',
     multisigConfigured: false,
     createdAt: new Date(),
@@ -165,14 +167,18 @@ describe('EscrowService', () => {
       getOrCreateStellarAccount: jest.fn(),
     };
 
+    const configService = {
+      getOrThrow: jest.fn((key: string) => CONFIG_VALUES[key]),
+      get: jest.fn((key: string) => CONFIG_VALUES[key]),
+    } as unknown as ConfigService;
+
     service = new EscrowService(
       escrowRepository as unknown as EscrowRepository,
       stellarAccountRepository as unknown as StellarAccountRepository,
       paymentsService as unknown as PaymentsService,
       {} as unknown as DefaultStellarClient,
-      {
-        getOrThrow: jest.fn((key: string) => CONFIG_VALUES[key]),
-      } as unknown as ConfigService,
+      configService,
+      new WalletResolver(configService),
     );
   });
 

--- a/apps/api/src/modules/payments/escrow.service.ts
+++ b/apps/api/src/modules/payments/escrow.service.ts
@@ -11,13 +11,11 @@ import {
   depositToEscrow,
   DefaultStellarClient,
   getEscrow,
-  KeypairWallet,
   refundEscrow,
   releaseEscrow,
   SorobanInvocationError,
 } from '@mixmatch/stellar';
 import type { DepositEscrowInput } from '@mixmatch/shared';
-import { decryptSecretKey } from './wallet-encryption';
 import { PaymentsService } from './payments.service';
 import {
   DuplicateEscrowIdempotencyKeyError,
@@ -25,6 +23,7 @@ import {
   type EscrowRecord,
 } from './escrow.repository';
 import { StellarAccountRepository } from './stellar-account.repository';
+import { WalletResolver } from './wallet-resolver';
 
 /** Mirrors `PaymentFailedError`'s HTTP-facing shape for Soroban escrow invocation failures. */
 export class EscrowFailedError extends HttpException {
@@ -41,6 +40,7 @@ export class EscrowService {
     private readonly paymentsService: PaymentsService,
     private readonly stellarClient: DefaultStellarClient,
     private readonly configService: ConfigService,
+    private readonly walletResolver: WalletResolver,
   ) {}
 
   /**
@@ -78,10 +78,7 @@ export class EscrowService {
       throw error;
     }
 
-    const wallet = KeypairWallet.fromSecret(
-      account.network,
-      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
-    );
+    const wallet = await this.walletResolver.walletForAccount(account);
 
     try {
       const result = await depositToEscrow({
@@ -138,10 +135,7 @@ export class EscrowService {
     if (!account) {
       throw new NotFoundException('Stellar account not found');
     }
-    const wallet = KeypairWallet.fromSecret(
-      account.network,
-      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
-    );
+    const wallet = await this.walletResolver.walletForAccount(account);
 
     try {
       const result = await releaseEscrow({
@@ -176,10 +170,7 @@ export class EscrowService {
     if (!account) {
       throw new NotFoundException('Stellar account not found');
     }
-    const wallet = KeypairWallet.fromSecret(
-      account.network,
-      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
-    );
+    const wallet = await this.walletResolver.walletForAccount(account);
 
     try {
       const result = await refundEscrow({
@@ -225,9 +216,5 @@ export class EscrowService {
 
   private escrowContractId(): string {
     return this.configService.getOrThrow<string>('stellarEscrowContractId');
-  }
-
-  private walletEncryptionKey(): string {
-    return this.configService.getOrThrow<string>('walletEncryptionKey');
   }
 }

--- a/apps/api/src/modules/payments/payments.module.ts
+++ b/apps/api/src/modules/payments/payments.module.ts
@@ -13,6 +13,7 @@ import { PaymentsService } from './payments.service';
 import { ReconciliationJob } from './reconciliation.job';
 import { StellarAccountRepository } from './stellar-account.repository';
 import { TransactionRepository } from './transaction.repository';
+import { WalletResolver } from './wallet-resolver';
 
 @Module({
   imports: [AuthModule, StellarModule],
@@ -31,6 +32,7 @@ import { TransactionRepository } from './transaction.repository';
     EscrowRepository,
     AnchorService,
     AnchorTransactionRepository,
+    WalletResolver,
   ],
   exports: [PaymentsService],
 })

--- a/apps/api/src/modules/payments/payments.service.spec.ts
+++ b/apps/api/src/modules/payments/payments.service.spec.ts
@@ -1,5 +1,6 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import type { ConfigService } from '@nestjs/config';
+import { WalletResolver } from './wallet-resolver';
 import { Keypair } from '@stellar/stellar-sdk';
 import {
   StellarPaymentError,
@@ -160,6 +161,7 @@ function buildAccount(
     userId: 'user-1',
     publicKey: 'GABCDEF',
     encryptedSecretKey: encryptSecretKey(REAL_TESTNET_SECRET, ENCRYPTION_KEY),
+    signingKeyId: null,
     network: 'testnet',
     multisigConfigured: false,
     createdAt: new Date(),
@@ -238,15 +240,18 @@ describe('PaymentsService', () => {
       horizon: { friendbot: jest.fn() },
     };
 
+    const configService = {
+      getOrThrow: jest.fn((key: string) => CONFIG_VALUES[key]),
+      get: jest.fn((key: string) => CONFIG_VALUES[key]),
+    } as unknown as ConfigService;
+
     service = new PaymentsService(
       stellarAccountRepository as unknown as StellarAccountRepository,
       transactionRepository as unknown as TransactionRepository,
       stellarClient as unknown as DefaultStellarClient,
       paymentEngine as unknown as StellarPaymentEngine,
-      {
-        getOrThrow: jest.fn((key: string) => CONFIG_VALUES[key]),
-        get: jest.fn((key: string) => CONFIG_VALUES[key]),
-      } as unknown as ConfigService,
+      configService,
+      new WalletResolver(configService),
     );
   });
 

--- a/apps/api/src/modules/payments/payments.service.ts
+++ b/apps/api/src/modules/payments/payments.service.ts
@@ -15,8 +15,6 @@ import {
   findStrictReceivePath,
   findStrictSendPath,
   fundTestnetAccount,
-  generateStellarAccount,
-  KeypairWallet,
   StellarPaymentError,
   StellarPaymentService as StellarPaymentEngine,
   streamAccountPayments,
@@ -34,7 +32,6 @@ import type {
   SendPaymentInput,
 } from '@mixmatch/shared';
 import { PaymentFailedError } from './payment-errors';
-import { decryptSecretKey, encryptSecretKey } from './wallet-encryption';
 import {
   StellarAccountRepository,
   type StellarAccountRecord,
@@ -44,6 +41,7 @@ import {
   TransactionRepository,
   type TransactionRecord,
 } from './transaction.repository';
+import { WalletResolver } from './wallet-resolver';
 
 function normalizeAmount(amount: string): string {
   return Number(amount).toFixed(7);
@@ -64,6 +62,7 @@ export class PaymentsService {
     private readonly stellarClient: DefaultStellarClient,
     private readonly paymentEngine: StellarPaymentEngine,
     private readonly configService: ConfigService,
+    private readonly walletResolver: WalletResolver,
   ) {}
 
   /** Returns the caller's Stellar account, provisioning (and, on testnet, funding) one on first use. */
@@ -76,24 +75,23 @@ export class PaymentsService {
     }
 
     const network = this.stellarClient.getNetwork();
-    const generated = generateStellarAccount();
+    const signer = await this.walletResolver.createAccountSigner();
 
     if (network === 'testnet') {
       await fundTestnetAccount(
         this.stellarClient.horizon,
         network,
-        generated.publicKey,
+        signer.publicKey,
       );
     }
 
     return this.stellarAccountRepository.create({
       userId,
-      publicKey: generated.publicKey,
-      encryptedSecretKey: encryptSecretKey(
-        generated.wallet.secretKey,
-        this.walletEncryptionKey(),
-      ),
+      publicKey: signer.publicKey,
       network,
+      ...('signingKeyId' in signer
+        ? { signingKeyId: signer.signingKeyId }
+        : { encryptedSecretKey: signer.encryptedSecretKey }),
     });
   }
 
@@ -156,10 +154,7 @@ export class PaymentsService {
       throw error;
     }
 
-    const wallet = KeypairWallet.fromSecret(
-      account.network,
-      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
-    );
+    const wallet = await this.walletResolver.walletForAccount(account);
 
     try {
       const result = quote
@@ -214,7 +209,11 @@ export class PaymentsService {
     input: SendPaymentInput,
     quote: PathQuote | undefined,
   ): boolean {
-    if (!this.adminSigningSecret() || quote || input.assetCode) {
+    if (
+      !this.walletResolver.adminSigningConfigured() ||
+      quote ||
+      input.assetCode
+    ) {
       return false;
     }
     return Number(input.amount) > Number(this.highValueThresholdAmount());
@@ -243,11 +242,12 @@ export class PaymentsService {
 
     let currentAccount = account;
     if (!currentAccount.multisigConfigured) {
-      const wallet = this.walletForAccount(currentAccount);
+      const wallet = await this.walletResolver.walletForAccount(currentAccount);
+      const admin = await this.walletResolver.adminWallet();
       await configureMultisig({
         client: this.stellarClient,
         wallet,
-        adminPublicKey: this.adminWallet().publicKey,
+        adminPublicKey: admin.publicKey,
       });
       currentAccount =
         await this.stellarAccountRepository.markMultisigConfigured(
@@ -255,7 +255,7 @@ export class PaymentsService {
         );
     }
 
-    const wallet = this.walletForAccount(currentAccount);
+    const wallet = await this.walletResolver.walletForAccount(currentAccount);
     const { envelopeXdr } = await buildHighValuePaymentEnvelope({
       client: this.stellarClient,
       sourceWallet: wallet,
@@ -300,7 +300,7 @@ export class PaymentsService {
       const result = await coSignAndSubmitEnvelope({
         client: this.stellarClient,
         envelopeXdr: transaction.pendingEnvelopeXdr as string,
-        adminWallet: this.adminWallet(),
+        adminWallet: await this.walletResolver.adminWallet(),
       });
       return await this.transactionRepository.updateStatus(transaction.id, {
         status: 'SUCCESS',
@@ -363,28 +363,6 @@ export class PaymentsService {
       );
     }
     return transaction;
-  }
-
-  private walletForAccount(account: StellarAccountRecord): KeypairWallet {
-    return KeypairWallet.fromSecret(
-      account.network,
-      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
-    );
-  }
-
-  private adminWallet(): KeypairWallet {
-    return KeypairWallet.fromSecret(
-      this.stellarClient.getNetwork(),
-      this.adminSigningSecretOrThrow(),
-    );
-  }
-
-  private adminSigningSecret(): string | undefined {
-    return this.configService.get<string>('adminSigningSecret');
-  }
-
-  private adminSigningSecretOrThrow(): string {
-    return this.configService.getOrThrow<string>('adminSigningSecret');
   }
 
   private highValueThresholdAmount(): string {
@@ -493,10 +471,7 @@ export class PaymentsService {
     input: EstablishTrustlineInput,
   ): Promise<EstablishTrustlineResponse> {
     const account = await this.getOrCreateStellarAccount(userId);
-    const wallet = KeypairWallet.fromSecret(
-      account.network,
-      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
-    );
+    const wallet = await this.walletResolver.walletForAccount(account);
 
     try {
       const result = await establishTrustline({
@@ -825,9 +800,5 @@ export class PaymentsService {
 
   private reconciliationEscalationMs(): number {
     return this.configService.getOrThrow<number>('reconciliationEscalationMs');
-  }
-
-  private walletEncryptionKey(): string {
-    return this.configService.getOrThrow<string>('walletEncryptionKey');
   }
 }

--- a/apps/api/src/modules/payments/stellar-account.repository.ts
+++ b/apps/api/src/modules/payments/stellar-account.repository.ts
@@ -9,7 +9,10 @@ export interface StellarAccountRecord {
   id: string;
   userId: string;
   publicKey: string;
-  encryptedSecretKey: string;
+  /** Set only for legacy accounts predating the Vault/KMS migration. */
+  encryptedSecretKey: string | null;
+  /** Vault transit key name; set for every account created after the Vault/KMS migration. */
+  signingKeyId: string | null;
   network: StellarNetwork;
   multisigConfigured: boolean;
   createdAt: Date;
@@ -38,12 +41,21 @@ export class StellarAccountRepository {
     return row ?? null;
   }
 
-  async create(input: {
-    userId: string;
-    publicKey: string;
-    encryptedSecretKey: string;
-    network: StellarNetwork;
-  }): Promise<StellarAccountRecord> {
+  async create(
+    input:
+      | {
+          userId: string;
+          publicKey: string;
+          encryptedSecretKey: string;
+          network: StellarNetwork;
+        }
+      | {
+          userId: string;
+          publicKey: string;
+          signingKeyId: string;
+          network: StellarNetwork;
+        },
+  ): Promise<StellarAccountRecord> {
     const [row] = await this.db
       .insert(schema.stellarAccounts)
       .values(input)

--- a/apps/api/src/modules/payments/wallet-resolver.spec.ts
+++ b/apps/api/src/modules/payments/wallet-resolver.spec.ts
@@ -1,0 +1,180 @@
+import type { ConfigService } from '@nestjs/config';
+import { Keypair } from '@stellar/stellar-sdk';
+import { KeypairWallet, VaultWallet } from '@mixmatch/stellar';
+import { encryptSecretKey } from './wallet-encryption';
+import { WalletResolver } from './wallet-resolver';
+import type { StellarAccountRecord } from './stellar-account.repository';
+
+const createSigningKeyMock = jest.fn<Promise<void>, [string]>();
+const getPublicKeyMock = jest.fn<Promise<Buffer>, [string]>();
+const signMock = jest.fn<Promise<Buffer>, [string, Buffer]>();
+
+jest.mock('@mixmatch/kms', () => ({
+  VaultTransitClient: jest.fn().mockImplementation(() => ({
+    createSigningKey: createSigningKeyMock,
+    getPublicKey: getPublicKeyMock,
+    sign: signMock,
+  })),
+}));
+
+const ENCRYPTION_KEY = 'ab'.repeat(32);
+
+function buildAccount(
+  overrides: Partial<StellarAccountRecord> = {},
+): StellarAccountRecord {
+  return {
+    id: 'account-1',
+    userId: 'user-1',
+    publicKey: 'GABCDEF',
+    encryptedSecretKey: null,
+    signingKeyId: null,
+    network: 'testnet',
+    multisigConfigured: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function buildConfigService(values: Record<string, unknown>): ConfigService {
+  return {
+    get: jest.fn((key: string) => values[key]),
+    getOrThrow: jest.fn((key: string) => {
+      if (values[key] === undefined) {
+        throw new Error(`Missing config: ${key}`);
+      }
+      return values[key];
+    }),
+  } as unknown as ConfigService;
+}
+
+describe('WalletResolver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('without Vault configured', () => {
+    it('resolves a legacy account via KeypairWallet', async () => {
+      const secret = Keypair.random().secret();
+      const resolver = new WalletResolver(
+        buildConfigService({ walletEncryptionKey: ENCRYPTION_KEY }),
+      );
+
+      const account = buildAccount({
+        encryptedSecretKey: encryptSecretKey(secret, ENCRYPTION_KEY),
+      });
+      const wallet = await resolver.walletForAccount(account);
+
+      expect(wallet).toBeInstanceOf(KeypairWallet);
+      expect(wallet.publicKey).toBe(Keypair.fromSecret(secret).publicKey());
+    });
+
+    it('creates a new account via a locally-generated encrypted keypair', async () => {
+      const resolver = new WalletResolver(
+        buildConfigService({ walletEncryptionKey: ENCRYPTION_KEY }),
+      );
+
+      const signer = await resolver.createAccountSigner();
+
+      expect(signer).toHaveProperty('encryptedSecretKey');
+      expect(createSigningKeyMock).not.toHaveBeenCalled();
+    });
+
+    it('vaultConfigured() and adminSigningConfigured() report false unless configured', () => {
+      const resolver = new WalletResolver(buildConfigService({}));
+      expect(resolver.vaultConfigured()).toBe(false);
+      expect(resolver.adminSigningConfigured()).toBe(false);
+    });
+
+    it('adminWallet() falls back to the legacy admin secret', async () => {
+      const adminSecret = Keypair.random().secret();
+      const resolver = new WalletResolver(
+        buildConfigService({
+          adminSigningSecret: adminSecret,
+          stellarNetwork: 'testnet',
+        }),
+      );
+
+      const wallet = await resolver.adminWallet();
+
+      expect(wallet).toBeInstanceOf(KeypairWallet);
+      expect(wallet.publicKey).toBe(
+        Keypair.fromSecret(adminSecret).publicKey(),
+      );
+    });
+  });
+
+  describe('with Vault configured', () => {
+    function vaultConfigService(extra: Record<string, unknown> = {}) {
+      return buildConfigService({
+        vaultAddr: 'http://127.0.0.1:8200',
+        vaultToken: 'test-token',
+        stellarNetwork: 'testnet',
+        ...extra,
+      });
+    }
+
+    it('provisions a new account by creating a Vault transit key', async () => {
+      const keypair = Keypair.random();
+      createSigningKeyMock.mockResolvedValue(undefined);
+      getPublicKeyMock.mockResolvedValue(keypair.rawPublicKey());
+
+      const resolver = new WalletResolver(vaultConfigService());
+      const signer = await resolver.createAccountSigner();
+
+      expect(signer).toHaveProperty('signingKeyId');
+      expect(signer.publicKey).toBe(keypair.publicKey());
+      expect(createSigningKeyMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves an account with a signingKeyId via VaultWallet', async () => {
+      const keypair = Keypair.random();
+      getPublicKeyMock.mockResolvedValue(keypair.rawPublicKey());
+
+      const resolver = new WalletResolver(vaultConfigService());
+      const account = buildAccount({ signingKeyId: 'stellar-account-1' });
+      const wallet = await resolver.walletForAccount(account);
+
+      expect(wallet).toBeInstanceOf(VaultWallet);
+      expect(wallet.publicKey).toBe(keypair.publicKey());
+    });
+
+    it('resolves the admin wallet from a Vault key name', async () => {
+      const keypair = Keypair.random();
+      getPublicKeyMock.mockResolvedValue(keypair.rawPublicKey());
+
+      const resolver = new WalletResolver(
+        vaultConfigService({ adminSigningKeyName: 'platform-admin' }),
+      );
+      const wallet = await resolver.adminWallet();
+
+      expect(wallet).toBeInstanceOf(VaultWallet);
+      expect(wallet.publicKey).toBe(keypair.publicKey());
+      expect(getPublicKeyMock).toHaveBeenCalledWith('platform-admin');
+    });
+
+    it('adminSigningConfigured() requires adminSigningKeyName once Vault is on', () => {
+      const resolver = new WalletResolver(vaultConfigService());
+      expect(resolver.adminSigningConfigured()).toBe(false);
+
+      const configured = new WalletResolver(
+        vaultConfigService({ adminSigningKeyName: 'platform-admin' }),
+      );
+      expect(configured.adminSigningConfigured()).toBe(true);
+    });
+
+    it('never touches encryptedSecretKey/decryptSecretKey when the account uses a signingKeyId', async () => {
+      const keypair = Keypair.random();
+      getPublicKeyMock.mockResolvedValue(keypair.rawPublicKey());
+      const resolver = new WalletResolver(vaultConfigService());
+      const account = buildAccount({
+        signingKeyId: 'stellar-account-1',
+        encryptedSecretKey: 'not-real-ciphertext',
+      });
+
+      await expect(resolver.walletForAccount(account)).resolves.toBeInstanceOf(
+        VaultWallet,
+      );
+    });
+  });
+});

--- a/apps/api/src/modules/payments/wallet-resolver.ts
+++ b/apps/api/src/modules/payments/wallet-resolver.ts
@@ -1,0 +1,138 @@
+import { randomUUID } from 'node:crypto';
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { VaultTransitClient } from '@mixmatch/kms';
+import {
+  generateStellarAccount,
+  KeypairWallet,
+  VaultWallet,
+  type StellarNetwork,
+  type Wallet,
+} from '@mixmatch/stellar';
+import { StrKey } from '@stellar/stellar-sdk';
+import { decryptSecretKey, encryptSecretKey } from './wallet-encryption';
+import type { StellarAccountRecord } from './stellar-account.repository';
+
+/**
+ * Resolves signing capability for a Stellar account, dispatching on which
+ * key-custody model that account uses: `signingKeyId` → Vault-backed
+ * `VaultWallet` (every account created after the KMS migration; see
+ * `apps/api/src/modules/payments/README.md`'s "Wallet custody" section),
+ * or `encryptedSecretKey` → legacy `KeypairWallet` (accounts created
+ * before it, kept working indefinitely but never used for new accounts).
+ *
+ * Also owns admin-co-signer resolution (`adminWallet`) and provisioning a
+ * brand-new account's signing key (`createAccountSigner`), so every path
+ * that used to reach directly into `WALLET_ENCRYPTION_KEY`/`Keypair`
+ * material now goes through one chokepoint instead of duplicating the
+ * branch in four services.
+ */
+@Injectable()
+export class WalletResolver {
+  private vaultClient: VaultTransitClient | undefined;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  /** True once VAULT_ADDR/VAULT_TOKEN are configured — the gate for using Vault at all. */
+  vaultConfigured(): boolean {
+    return Boolean(this.configService.get<string>('vaultAddr'));
+  }
+
+  /** True once an admin co-signer is configured (Vault-backed or legacy secret) — the gate for the high-value-payment flow. */
+  adminSigningConfigured(): boolean {
+    return this.vaultConfigured()
+      ? Boolean(this.configService.get<string>('adminSigningKeyName'))
+      : Boolean(this.configService.get<string>('adminSigningSecret'));
+  }
+
+  async walletForAccount(account: StellarAccountRecord): Promise<Wallet> {
+    if (account.signingKeyId) {
+      const publicKeyBytes = await this.client().getPublicKey(
+        account.signingKeyId,
+      );
+      return new VaultWallet(
+        account.network,
+        StrKey.encodeEd25519PublicKey(publicKeyBytes),
+        account.signingKeyId,
+        this.client(),
+      );
+    }
+    if (!account.encryptedSecretKey) {
+      throw new Error(
+        `Stellar account ${account.id} has neither signingKeyId nor encryptedSecretKey`,
+      );
+    }
+    return KeypairWallet.fromSecret(
+      account.network,
+      decryptSecretKey(account.encryptedSecretKey, this.walletEncryptionKey()),
+    );
+  }
+
+  /**
+   * Provisions signing capability for a brand-new account: a Vault
+   * transit key if Vault is configured, otherwise a locally-generated
+   * (and immediately AES-256-GCM-encrypted) keypair — the same legacy
+   * behavior as before this migration, kept as the no-Vault fallback for
+   * local development.
+   */
+  async createAccountSigner(): Promise<
+    | { publicKey: string; signingKeyId: string }
+    | { publicKey: string; encryptedSecretKey: string }
+  > {
+    if (this.vaultConfigured()) {
+      const keyName = `stellar-account-${randomUUID()}`;
+      await this.client().createSigningKey(keyName);
+      const publicKeyBytes = await this.client().getPublicKey(keyName);
+      return {
+        publicKey: StrKey.encodeEd25519PublicKey(publicKeyBytes),
+        signingKeyId: keyName,
+      };
+    }
+
+    const generated = generateStellarAccount();
+    return {
+      publicKey: generated.publicKey,
+      encryptedSecretKey: encryptSecretKey(
+        generated.wallet.secretKey,
+        this.walletEncryptionKey(),
+      ),
+    };
+  }
+
+  /** The platform's admin co-signing wallet, used to approve high-value payments. */
+  async adminWallet(): Promise<Wallet> {
+    if (this.vaultConfigured()) {
+      const keyName = this.configService.getOrThrow<string>(
+        'adminSigningKeyName',
+      );
+      const publicKeyBytes = await this.client().getPublicKey(keyName);
+      return new VaultWallet(
+        this.stellarNetwork(),
+        StrKey.encodeEd25519PublicKey(publicKeyBytes),
+        keyName,
+        this.client(),
+      );
+    }
+    return KeypairWallet.fromSecret(
+      this.stellarNetwork(),
+      this.configService.getOrThrow<string>('adminSigningSecret'),
+    );
+  }
+
+  private client(): VaultTransitClient {
+    this.vaultClient ??= new VaultTransitClient({
+      address: this.configService.getOrThrow<string>('vaultAddr'),
+      token: this.configService.getOrThrow<string>('vaultToken'),
+      mountPath: this.configService.get<string>('vaultTransitMountPath'),
+    });
+    return this.vaultClient;
+  }
+
+  private stellarNetwork(): StellarNetwork {
+    return this.configService.getOrThrow<StellarNetwork>('stellarNetwork');
+  }
+
+  private walletEncryptionKey(): string {
+    return this.configService.getOrThrow<string>('walletEncryptionKey');
+  }
+}

--- a/packages/kms/README.md
+++ b/packages/kms/README.md
@@ -1,0 +1,5 @@
+# @mixmatch/kms
+
+Thin client for HashiCorp Vault's transit secrets engine, used as the KMS backend for Stellar account signing keys — see `apps/api/src/modules/payments/README.md`'s "Wallet custody" section for the full rationale and setup.
+
+`VaultTransitClient` never returns key material: every key is created with `exportable: false` / `allow_plaintext_backup: false`, so the only things it hands back are a public key (`getPublicKey`) and a signature over caller-supplied data (`sign`). Consumed by `@mixmatch/stellar`'s `VaultWallet`, which structurally satisfies its `RemoteSigner` interface — this package has no dependency on `@mixmatch/stellar` or vice versa.

--- a/packages/kms/eslint.config.mjs
+++ b/packages/kms/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { config } from '@repo/eslint-config/base';
+
+export default config;

--- a/packages/kms/package.json
+++ b/packages/kms/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@mixmatch/kms",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "lint": "eslint . --max-warnings 0",
+    "test": "vitest run",
+    "check-types": "tsc -p tsconfig.json --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "@types/node": "^22.15.3",
+    "eslint": "^9.39.1",
+    "typescript": "5.9.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/kms/src/__tests__/vault-transit-client.test.ts
+++ b/packages/kms/src/__tests__/vault-transit-client.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { VaultTransitClient, VaultTransitError } from '../vault-transit-client.js';
+
+const config = { address: 'http://127.0.0.1:8200', token: 'test-token' };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('VaultTransitClient.createSigningKey', () => {
+  it('POSTs to /v1/transit/keys/:name with a non-exportable ed25519 key spec, authenticated via X-Vault-Token', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({ data: {} }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await new VaultTransitClient(config).createSigningKey('account-1');
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://127.0.0.1:8200/v1/transit/keys/account-1');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['X-Vault-Token']).toBe('test-token');
+    const body = JSON.parse(String(init.body)) as { type: string; exportable: boolean; allow_plaintext_backup: boolean };
+    expect(body).toEqual({ type: 'ed25519', exportable: false, allow_plaintext_backup: false });
+  });
+
+  it('throws VaultTransitError when Vault rejects the request', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 400, text: () => Promise.resolve('{"errors":["bad request"]}') }),
+    );
+
+    await expect(new VaultTransitClient(config).createSigningKey('account-1')).rejects.toBeInstanceOf(
+      VaultTransitError,
+    );
+  });
+});
+
+describe('VaultTransitClient.getPublicKey', () => {
+  it('returns the raw public key bytes for the latest key version', async () => {
+    const publicKeyBase64 = Buffer.from('a'.repeat(32)).toString('base64');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            data: { latest_version: 1, keys: { '1': { public_key: publicKeyBase64 } } },
+          }),
+      }),
+    );
+
+    const publicKey = await new VaultTransitClient(config).getPublicKey('account-1');
+
+    expect(publicKey).toEqual(Buffer.from(publicKeyBase64, 'base64'));
+  });
+
+  it('uses the latest_version to select which key entry to read', async () => {
+    const publicKeyBase64 = Buffer.from('b'.repeat(32)).toString('base64');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            data: {
+              latest_version: 2,
+              keys: {
+                '1': { public_key: Buffer.from('old'.repeat(11)).toString('base64') },
+                '2': { public_key: publicKeyBase64 },
+              },
+            },
+          }),
+      }),
+    );
+
+    const publicKey = await new VaultTransitClient(config).getPublicKey('account-1');
+
+    expect(publicKey).toEqual(Buffer.from(publicKeyBase64, 'base64'));
+  });
+
+  it('throws VaultTransitError when the response has no public key', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: { latest_version: 1, keys: {} } }),
+      }),
+    );
+
+    await expect(new VaultTransitClient(config).getPublicKey('account-1')).rejects.toBeInstanceOf(
+      VaultTransitError,
+    );
+  });
+});
+
+describe('VaultTransitClient.sign', () => {
+  it('sends base64-encoded input and extracts the signature from Vault\'s "vault:v1:<sig>" format', async () => {
+    const rawSignature = Buffer.from('c'.repeat(64));
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ data: { signature: `vault:v1:${rawSignature.toString('base64')}` } }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const data = Buffer.from('transaction-hash-bytes');
+    const signature = await new VaultTransitClient(config).sign('account-1', data);
+
+    expect(signature).toEqual(rawSignature);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://127.0.0.1:8200/v1/transit/sign/account-1');
+    const body = JSON.parse(String(init.body)) as { input: string };
+    expect(body.input).toBe(data.toString('base64'));
+  });
+
+  it('throws VaultTransitError on a network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    await expect(new VaultTransitClient(config).sign('account-1', Buffer.from('x'))).rejects.toThrow();
+  });
+});
+
+describe('VaultTransitClient mount path', () => {
+  it('honors a custom transit mount path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({ data: {} }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await new VaultTransitClient({ ...config, mountPath: 'custom-transit' }).createSigningKey('account-1');
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe('http://127.0.0.1:8200/v1/custom-transit/keys/account-1');
+  });
+});

--- a/packages/kms/src/index.ts
+++ b/packages/kms/src/index.ts
@@ -1,0 +1,1 @@
+export * from './vault-transit-client.js';

--- a/packages/kms/src/vault-transit-client.ts
+++ b/packages/kms/src/vault-transit-client.ts
@@ -1,0 +1,111 @@
+/**
+ * Thin client for HashiCorp Vault's transit secrets engine, used as the
+ * KMS backend for Stellar account signing keys (see
+ * `apps/api/src/modules/payments/README.md`'s "Wallet custody" section
+ * for the full rationale). Every key is created with `exportable: false`
+ * and `allow_plaintext_backup: false` — Vault signs on request but never
+ * hands back key material, so no caller (including this client) ever
+ * holds a raw secret key.
+ */
+export interface VaultTransitConfig {
+  /** e.g. "http://127.0.0.1:8200" for a local dev server. */
+  address: string;
+  /** A Vault token authorized for the transit mount's create/read/sign paths. */
+  token: string;
+  /** Transit secrets engine mount path. Defaults to "transit". */
+  mountPath?: string;
+}
+
+export class VaultTransitError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'VaultTransitError';
+  }
+}
+
+interface VaultKeyReadResponse {
+  data: {
+    keys: Record<string, { public_key: string }>;
+    latest_version: number;
+  };
+}
+
+interface VaultSignResponse {
+  data: {
+    signature: string;
+  };
+}
+
+export class VaultTransitClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+
+  constructor(config: VaultTransitConfig) {
+    this.baseUrl = `${config.address.replace(/\/$/, '')}/v1/${config.mountPath ?? 'transit'}`;
+    this.token = config.token;
+  }
+
+  /**
+   * Creates a new non-exportable ed25519 signing key inside Vault. Idempotent
+   * in the sense that Vault errors if the name is already taken — callers
+   * should pick a name that's unique per account (e.g. the account's own id).
+   */
+  async createSigningKey(keyName: string): Promise<void> {
+    await this.request(`/keys/${encodeURIComponent(keyName)}`, {
+      method: 'POST',
+      body: JSON.stringify({
+        type: 'ed25519',
+        exportable: false,
+        allow_plaintext_backup: false,
+      }),
+    });
+  }
+
+  /** Returns the raw 32-byte ed25519 public key for a signing key's latest version. */
+  async getPublicKey(keyName: string): Promise<Buffer> {
+    const response = await this.request<VaultKeyReadResponse>(`/keys/${encodeURIComponent(keyName)}`, {
+      method: 'GET',
+    });
+    const latestVersion = String(response.data.latest_version);
+    const publicKeyBase64 = response.data.keys[latestVersion]?.public_key;
+    if (!publicKeyBase64) {
+      throw new VaultTransitError(`No public key found for signing key "${keyName}"`);
+    }
+    return Buffer.from(publicKeyBase64, 'base64');
+  }
+
+  /** Signs `data` with the named key, returning the raw 64-byte ed25519 signature. Vault never returns key material — only this signature. */
+  async sign(keyName: string, data: Buffer): Promise<Buffer> {
+    const response = await this.request<VaultSignResponse>(`/sign/${encodeURIComponent(keyName)}`, {
+      method: 'POST',
+      body: JSON.stringify({ input: data.toString('base64') }),
+    });
+    // Vault's own signature format is "vault:v<version>:<base64>".
+    const parts = response.data.signature.split(':');
+    const signatureBase64 = parts[parts.length - 1];
+    if (!signatureBase64) {
+      throw new VaultTransitError(`Malformed signature response for key "${keyName}"`);
+    }
+    return Buffer.from(signatureBase64, 'base64');
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      ...init,
+      headers: { 'X-Vault-Token': this.token, 'Content-Type': 'application/json' },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new VaultTransitError(`Vault request to ${path} failed: HTTP ${response.status} ${body}`.trim(), response.status);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+    return (await response.json()) as T;
+  }
+}

--- a/packages/kms/tsconfig.build.json
+++ b/packages/kms/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/__tests__", "dist"]
+}

--- a/packages/kms/tsconfig.json
+++ b/packages/kms/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["es2022"],
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/kms/vitest.config.ts
+++ b/packages/kms/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/stellar/src/__tests__/wallet.test.ts
+++ b/packages/stellar/src/__tests__/wallet.test.ts
@@ -1,6 +1,14 @@
-import { Keypair } from '@stellar/stellar-sdk';
-import { describe, expect, it } from 'vitest';
-import { KeypairWallet } from '../wallet.js';
+import { Account, Keypair, Networks, Operation, TransactionBuilder } from '@stellar/stellar-sdk';
+import { describe, expect, it, vi } from 'vitest';
+import { KeypairWallet, VaultWallet } from '../wallet.js';
+
+function buildTestTransaction(sourcePublicKey: string) {
+  const account = new Account(sourcePublicKey, '0');
+  return new TransactionBuilder(account, { fee: '100', networkPassphrase: Networks.TESTNET })
+    .addOperation(Operation.bumpSequence({ bumpTo: '1' }))
+    .setTimeout(30)
+    .build();
+}
 
 describe('KeypairWallet', () => {
   it('exposes the public key derived from the secret', () => {
@@ -11,16 +19,45 @@ describe('KeypairWallet', () => {
     expect(wallet.network).toBe('testnet');
   });
 
-  it('getKeypair() returns a keypair that can sign', () => {
+  it('sign() appends a valid signature for its own key to the transaction', async () => {
     const keypair = Keypair.random();
     const wallet = KeypairWallet.fromSecret('testnet', keypair.secret());
+    const transaction = buildTestTransaction(keypair.publicKey());
 
-    const signature = wallet.getKeypair().sign(Buffer.from('test-payload'));
-    expect(signature).toBeInstanceOf(Buffer);
-    expect(wallet.getKeypair().publicKey()).toBe(keypair.publicKey());
+    await wallet.sign(transaction);
+
+    expect(transaction.signatures).toHaveLength(1);
+    expect(keypair.verify(transaction.hash(), transaction.signatures[0]!.signature())).toBe(true);
   });
 
   it('throws for a malformed secret key', () => {
     expect(() => KeypairWallet.fromSecret('testnet', 'not-a-real-secret')).toThrow();
+  });
+});
+
+describe('VaultWallet', () => {
+  it('sign() requests a signature over the transaction hash and appends it via addSignature', async () => {
+    const keypair = Keypair.random();
+    const signer = {
+      sign: vi.fn(async (_keyName: string, data: Buffer) => keypair.sign(data)),
+    };
+    const wallet = new VaultWallet('testnet', keypair.publicKey(), 'account-1', signer);
+    const transaction = buildTestTransaction(keypair.publicKey());
+
+    await wallet.sign(transaction);
+
+    expect(signer.sign).toHaveBeenCalledWith('account-1', transaction.hash());
+    expect(transaction.signatures).toHaveLength(1);
+    expect(keypair.verify(transaction.hash(), transaction.signatures[0]!.signature())).toBe(true);
+  });
+
+  it('rejects a signature that does not match the wallet public key', async () => {
+    const keypair = Keypair.random();
+    const wrongSigner = Keypair.random();
+    const signer = { sign: vi.fn(async (_keyName: string, data: Buffer) => wrongSigner.sign(data)) };
+    const wallet = new VaultWallet('testnet', keypair.publicKey(), 'account-1', signer);
+    const transaction = buildTestTransaction(keypair.publicKey());
+
+    await expect(wallet.sign(transaction)).rejects.toThrow();
   });
 });

--- a/packages/stellar/src/escrow.ts
+++ b/packages/stellar/src/escrow.ts
@@ -107,7 +107,7 @@ async function submitInvocation(
     .build();
 
   const prepared = await client.soroban.prepareTransaction(transaction);
-  prepared.sign(signerWallet.getKeypair());
+  await signerWallet.sign(prepared);
 
   const sendResult = await client.soroban.sendTransaction(prepared);
   if (sendResult.status === 'ERROR') {

--- a/packages/stellar/src/multisig.ts
+++ b/packages/stellar/src/multisig.ts
@@ -54,7 +54,7 @@ export async function configureMultisig(params: ConfigureMultisigParams): Promis
       .setTimeout(TRANSACTION_TIMEOUT_SECONDS)
       .build();
 
-    transaction.sign(params.wallet.getKeypair());
+    await params.wallet.sign(transaction);
 
     const result = await params.client.horizon.submitTransaction(transaction);
     return { hash: result.hash, ledger: result.ledger };
@@ -116,7 +116,7 @@ export async function buildHighValuePaymentEnvelope(
     }
 
     const transaction = builder.setTimeout(TRANSACTION_TIMEOUT_SECONDS).build();
-    transaction.sign(params.sourceWallet.getKeypair());
+    await params.sourceWallet.sign(transaction);
 
     return { envelopeXdr: transaction.toXDR() };
   } catch (error) {
@@ -137,7 +137,7 @@ export async function coSignAndSubmitEnvelope(
 ): Promise<StellarPaymentResult> {
   try {
     const transaction = new Transaction(params.envelopeXdr, params.client.networkPassphrase);
-    transaction.sign(params.adminWallet.getKeypair());
+    await params.adminWallet.sign(transaction);
 
     const result = await params.client.horizon.submitTransaction(transaction);
     return { hash: result.hash, ledger: result.ledger };

--- a/packages/stellar/src/path-payment.ts
+++ b/packages/stellar/src/path-payment.ts
@@ -182,7 +182,7 @@ export async function submitPathPayment(params: SubmitPathPaymentParams): Promis
     }
 
     const transaction = builder.setTimeout(TRANSACTION_TIMEOUT_SECONDS).build();
-    transaction.sign(params.sourceWallet.getKeypair());
+    await params.sourceWallet.sign(transaction);
 
     const result = await params.client.horizon.submitTransaction(transaction);
     return { hash: result.hash, ledger: result.ledger };

--- a/packages/stellar/src/payment.ts
+++ b/packages/stellar/src/payment.ts
@@ -52,7 +52,7 @@ export class StellarPaymentService {
 
       const transaction = builder.setTimeout(TRANSACTION_TIMEOUT_SECONDS).build();
 
-      transaction.sign(params.sourceWallet.getKeypair());
+      await params.sourceWallet.sign(transaction);
 
       const result = await this.client.horizon.submitTransaction(transaction);
       return { hash: result.hash, ledger: result.ledger };

--- a/packages/stellar/src/sep/sep10.ts
+++ b/packages/stellar/src/sep/sep10.ts
@@ -57,7 +57,7 @@ export async function authenticateSep10(params: Sep10AuthParams): Promise<string
     throw new Error("SEP-10 challenge transaction is not signed by the anchor's signing key");
   }
 
-  transaction.sign(params.wallet.getKeypair());
+  await params.wallet.sign(transaction);
 
   const tokenResponse = await fetch(params.webAuthEndpoint, {
     method: 'POST',

--- a/packages/stellar/src/trustline.ts
+++ b/packages/stellar/src/trustline.ts
@@ -39,7 +39,7 @@ export async function establishTrustline(params: EstablishTrustlineParams): Prom
       .setTimeout(TRANSACTION_TIMEOUT_SECONDS)
       .build();
 
-    transaction.sign(params.wallet.getKeypair());
+    await params.wallet.sign(transaction);
 
     const result = await params.client.horizon.submitTransaction(transaction);
     return { hash: result.hash, ledger: result.ledger };

--- a/packages/stellar/src/wallet.ts
+++ b/packages/stellar/src/wallet.ts
@@ -1,20 +1,32 @@
-import { Keypair } from '@stellar/stellar-sdk';
+import { Keypair, Transaction } from '@stellar/stellar-sdk';
 import type { StellarNetwork } from './types/index.js';
 
 /**
  * Signing capability for a single Stellar account. Kept as an interface
- * (rather than exposing `Keypair` directly everywhere) so callers depend on
- * "something that can sign," not on how the secret key is held — this is
- * the seam a future non-custodial or KMS-backed signer implementation would
- * plug into without changing `StellarPaymentService`.
+ * (rather than exposing `Keypair` directly everywhere) so callers depend
+ * on "something that can sign a transaction," never on how — or whether —
+ * this implementation holds key material locally. `sign` is async
+ * specifically so a remote/KMS-backed signer (see `VaultWallet`) can fit
+ * the same shape as a local one: it never needs to expose a `Keypair` at
+ * all, so no caller can accidentally extract raw key material through
+ * this interface.
  */
 export interface Wallet {
   readonly network: StellarNetwork;
   readonly publicKey: string;
-  getKeypair(): Keypair;
+  /** Signs `transaction` in place (appends a signature), whatever that requires for this wallet. */
+  sign(transaction: Transaction): Promise<void>;
 }
 
-/** A wallet backed by a plaintext in-memory Stellar secret key. */
+/**
+ * A wallet backed by a plaintext in-memory Stellar secret key.
+ *
+ * @deprecated Kept only for the legacy `stellar_accounts` rows created
+ * before this platform moved signing keys into Vault (see
+ * `apps/api/src/modules/payments/README.md`'s "Wallet custody" section).
+ * Every new account is signed via `VaultWallet` instead — construct this
+ * only for a row that still has a non-null `encryptedSecretKey`.
+ */
 export class KeypairWallet implements Wallet {
   readonly network: StellarNetwork;
   readonly publicKey: string;
@@ -30,7 +42,39 @@ export class KeypairWallet implements Wallet {
     return new KeypairWallet(network, Keypair.fromSecret(secretKey));
   }
 
-  getKeypair(): Keypair {
-    return this.keypair;
+  sign(transaction: Transaction): Promise<void> {
+    transaction.sign(this.keypair);
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Signs by calling out to a remote signer (e.g. `@mixmatch/kms`'s
+ * `VaultTransitClient`) that holds the actual key material — this process
+ * never sees it, not even transiently. `RemoteSigner` is intentionally
+ * minimal and KMS-agnostic so `packages/stellar` doesn't need to depend on
+ * `@mixmatch/kms`; any object with a matching `sign` method satisfies it
+ * structurally.
+ */
+export interface RemoteSigner {
+  /** Signs `data` with the named key, returning the raw 64-byte ed25519 signature. */
+  sign(keyName: string, data: Buffer): Promise<Buffer>;
+}
+
+export class VaultWallet implements Wallet {
+  constructor(
+    readonly network: StellarNetwork,
+    readonly publicKey: string,
+    private readonly keyName: string,
+    private readonly signer: RemoteSigner,
+  ) {}
+
+  async sign(transaction: Transaction): Promise<void> {
+    const signature = await this.signer.sign(this.keyName, transaction.hash());
+    // Self-validating: addSignature verifies the signature against
+    // `publicKey` before appending it, so a mismatched/corrupt remote
+    // signature throws here rather than producing a silently-invalid
+    // transaction.
+    transaction.addSignature(this.publicKey, signature.toString('base64'));
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@mixmatch/kms':
+        specifier: workspace:*
+        version: link:../../packages/kms
       '@mixmatch/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -296,6 +299,27 @@ importers:
       typescript-eslint:
         specifier: ^8.50.0
         version: 8.50.0(eslint@9.39.1)(typescript@5.9.2)
+
+  packages/kms:
+    devDependencies:
+      '@repo/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.15.3
+      eslint:
+        specifier: ^9.39.1
+        version: 9.39.1
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.15.3)(jsdom@20.0.3)(lightningcss@1.33.0)(terser@5.49.0)
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
Introduce Vault-based KMS and a WalletResolver to support Vault-backed Stellar signing.

- Add @mixmatch/kms package with VaultTransitClient and tests.
- DB migration: make encrypted_secret_key nullable and add signing_key_id; update Drizzle schema and migration metadata.
- New WalletResolver service + tests and payments module wiring; services (Payments, Escrow, Anchor) now use it instead of direct key decryption.
- Stellar package: async Wallet.sign API and VaultWallet implementation; adapt callers.
- Env/config updates (VAULT_ADDR, VAULT_TOKEN, VAULT_TRANSIT_MOUNT_PATH, ADMIN_SIGNING_KEY_NAME) and docs/README for payments and KMS.

closes #862